### PR TITLE
[serde reflection] fix interaction between trace_value and trace_type in enums

### DIFF
--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -3,17 +3,72 @@
 
 #![forbid(unsafe_code)]
 
-//! # Serde Reflection
-//!
-//! This crate provides a way to extract IDL-like format descriptions for Rust containers
+//! This crate provides a way to extract format descriptions for Rust containers
 //! that implement the Serialize and/or Deserialize trait(s) of Serde.
+//!
+//! # Quick Start
+//!
+//! Very often, Serde traits are only implemented using Serde derive macros.
+//! In this case, simply
+//! * call `trace_type` on the desired top-level definitions, then
+//! * add a call to `trace_type` for each `enum` type. (This will fix any `MissingVariants` error.)
+//!
+//! ```rust
+//! # use serde::Deserialize;
+//! # use serde_reflection::{Error, Samples, Tracer, TracerConfig};
+//! #[derive(Deserialize)]
+//! struct Foo {
+//!   bar: Bar,
+//!   choice: Choice,
+//! }
+//!
+//! #[derive(Deserialize)]
+//! struct Bar(u64);
+//!
+//! #[derive(Deserialize)]
+//! enum Choice { A, B, C }
+//!
+//! # fn main() -> Result<(), Error> {
+//! // Start the tracing session.
+//! let mut tracer = Tracer::new(TracerConfig::default());
+//! let samples = Samples::new();
+//!
+//! // Trace the desired top-level type(s).
+//! tracer.trace_type::<Foo>(&samples)?;
+//!
+//! // Also trace each enum type separately to fix any `MissingVariants` error.
+//! tracer.trace_type::<Choice>(&samples)?;
+//!
+//! // Obtain the registry of Serde formats and serialize it in YAML.
+//! let registry = tracer.registry()?;
+//! let data = serde_yaml::to_string(&registry).unwrap() + "\n";
+//! assert_eq!(&data, r#"---
+//! Bar:
+//!   NEWTYPESTRUCT: U64
+//! Choice:
+//!   ENUM:
+//!     0:
+//!       A: UNIT
+//!     1:
+//!       B: UNIT
+//!     2:
+//!       C: UNIT
+//! Foo:
+//!   STRUCT:
+//!     - bar:
+//!         TYPENAME: Bar
+//!     - choice:
+//!         TYPENAME: Choice
+//! "#);
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! # Overview
 //!
-//! In the following example, we extract the Serde-generated data-format of two containers
-//! `Name` and `Person`. We also demonstrate how to handle a custom
-//! implementation of `ser::de::Deserialize` that would enforce user-defined invariants
-//! for `Name` values.
+//! In the following, more complete example, we extract the Serde formats of two containers
+//! `Name` and `Person` and demonstrate how to handle a custom implementation of `serde::Deserialize`
+//! for `Name`.
 //!
 //! ```rust
 //! # use serde::{Deserialize, Serialize};
@@ -212,12 +267,15 @@
 //! system requires us to return valid Rust values of type `V::Value`, where `V` is the type of
 //! a given `visitor`. This contraint limits the way we can stop graph traversal to only a few cases.
 //!
-//! The first 3 cases are what we have called *possible recursion points* above:
+//! The first 4 cases are what we have called *possible recursion points* above:
 //!
 //! * while visiting an `Option<T>` for the second time, we choose to return the value `None` to stop;
 //! * while visiting an `Seq<T>` for the second time, we choose to return the empty sequence `[]`;
+//! * while visiting an `Map<K, V>` for the second time, we choose to return the empty map `{}`;
 //! * while visiting an `enum T` for the second time, we choose to return the first variant, i.e.
 //! a "base case" by assumption (1) above.
+//!
+//! TODO ([#5](https://github.com/facebookincubator/serde-reflection/issues/5)): the detection of "the second time" above is currently only effective for enums.
 //!
 //! In addition to these 3 cases,
 //!


### PR DESCRIPTION
## Summary

`trace_type` was assuming that we find the variants of an enum starting with index 0. However, this doesn't need to be the case if we use trace_value first.

The new code is not making assumptions on the tracing state any longer. In the worst case, it may have to scan indexes to find a new variant, but the normal case is still O(1).

Also improve the documentation while we're at it.

## Test Plan

See new targeted unit test