### PR TITLE
[serde-generate] create new experimental tool to generate code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,10 @@ jobs:
           name: Setup Additional Languages
           command: |
             sudo apt-get update && sudo apt-get upgrade -y
-            sudo apt-get install python3-all-dev python3-numpy clang llvm
+            sudo apt-get install python3-all-dev python3-numpy clang llvm default-jdk
       - run:
           name: Version Information
-          command: rustc --version; cargo --version; rustup --version; python3 --version; clang++ --version
+          command: rustc --version; cargo --version; rustup --version; python3 --version; clang++ --version; javac -version
       - run:
           name: Setup Env
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,10 @@ jobs:
           name: Setup Additional Languages
           command: |
             sudo apt-get update && sudo apt-get upgrade -y
-            sudo apt-get install python3-all-dev python3-numpy
+            sudo apt-get install python3-all-dev python3-numpy clang llvm
       - run:
           name: Version Information
-          command: rustc --version; cargo --version; rustup --version; python3 --version
+          command: rustc --version; cargo --version; rustup --version; python3 --version; clang++ --version
       - run:
           name: Setup Env
           command: |

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -10,6 +10,7 @@
 
 Supported languages:
 * C++ 17
+* Java 8
 * Python 3
 * Rust 2018
 

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -9,6 +9,7 @@
 ## Serde code-generation library (experimental)
 
 Supported languages:
+* C++ 17
 * Python 3
 * Rust 2018
 

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -1,0 +1,341 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdint.h>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+using uint128_t = std::tuple<uint64_t, uint64_t>;
+using int128_t = std::tuple<int64_t, uint64_t>;
+
+/* -------- */
+
+template <typename T>
+struct Serializable {
+    template <typename Serializer>
+    static void serialize(const T &value, Serializer &serializer);
+};
+
+template <typename T>
+struct Deserializable {
+    template <typename Deserializer>
+    static T deserialize(Deserializer &deserializer);
+};
+
+/* -------- */
+
+template <typename T, typename Deleter>
+struct Serializable<std::unique_ptr<T, Deleter>> {
+    template <typename Serializer>
+    static void serialize(const std::unique_ptr<T, Deleter> &value,
+                          Serializer &serializer) {
+        Serializable<T>::serialize(*value, serializer);
+    }
+};
+
+template <typename T, typename Allocator>
+struct Serializable<std::vector<T, Allocator>> {
+    template <typename Serializer>
+    static void serialize(const std::vector<T, Allocator> &value,
+                          Serializer &serializer) {
+        serializer.serialize_len(value.size());
+        for (const T &item : value) {
+            Serializable<T>::serialize(item, serializer);
+        }
+    }
+};
+
+template <typename T, std::size_t N>
+struct Serializable<std::array<T, N>> {
+    template <typename Serializer>
+    static void serialize(const std::array<T, N> &value,
+                          Serializer &serializer) {
+        for (const T &item : value) {
+            Serializable<T>::serialize(item, serializer);
+        }
+    }
+};
+
+template <>
+struct Serializable<std::string> {
+    template <typename Serializer>
+    static void serialize(const std::string &value, Serializer &serializer) {
+        serializer.serialize_str(value);
+    }
+};
+
+template <>
+struct Serializable<uint8_t> {
+    template <typename Serializer>
+    static void serialize(const uint8_t &value, Serializer &serializer) {
+        serializer.serialize_u8(value);
+    }
+};
+
+template <>
+struct Serializable<uint16_t> {
+    template <typename Serializer>
+    static void serialize(const uint32_t &value, Serializer &serializer) {
+        serializer.serialize_u32(value);
+    }
+};
+
+template <>
+struct Serializable<uint32_t> {
+    template <typename Serializer>
+    static void serialize(const uint32_t &value, Serializer &serializer) {
+        serializer.serialize_u32(value);
+    }
+};
+
+template <>
+struct Serializable<uint64_t> {
+    template <typename Serializer>
+    static void serialize(const uint64_t &value, Serializer &serializer) {
+        serializer.serialize_u64(value);
+    }
+};
+
+template <>
+struct Serializable<uint128_t> {
+    template <typename Serializer>
+    static void serialize(const uint128_t &value, Serializer &serializer) {
+        serializer.serialize_u128(value);
+    }
+};
+
+template <>
+struct Serializable<int8_t> {
+    template <typename Serializer>
+    static void serialize(const int8_t &value, Serializer &serializer) {
+        serializer.serialize_i8(value);
+    }
+};
+
+template <>
+struct Serializable<int16_t> {
+    template <typename Serializer>
+    static void serialize(const int32_t &value, Serializer &serializer) {
+        serializer.serialize_i32(value);
+    }
+};
+
+template <>
+struct Serializable<int32_t> {
+    template <typename Serializer>
+    static void serialize(const int32_t &value, Serializer &serializer) {
+        serializer.serialize_i32(value);
+    }
+};
+
+template <>
+struct Serializable<int64_t> {
+    template <typename Serializer>
+    static void serialize(const int64_t &value, Serializer &serializer) {
+        serializer.serialize_i64(value);
+    }
+};
+
+template <>
+struct Serializable<int128_t> {
+    template <typename Serializer>
+    static void serialize(const int128_t &value, Serializer &serializer) {
+        serializer.serialize_i128(value);
+    }
+};
+
+// Must be defined after (u)int128_t.
+template <class... Types>
+struct Serializable<std::tuple<Types...>> {
+    template <typename Serializer>
+    static void serialize(const std::tuple<Types...> &value,
+                          Serializer &serializer) {
+        std::apply(
+            [&serializer](Types const &... args) {
+                (Serializable<Types>::serialize(args, serializer), ...);
+            },
+            value);
+    }
+};
+
+template <class... Types>
+struct Serializable<std::variant<Types...>> {
+    template <typename Serializer>
+    static void serialize(const std::variant<Types...> &value,
+                          Serializer &serializer) {
+        serializer.serialize_variant_index(value.index());
+        std::visit(
+            [&serializer](const auto &arg) {
+                using T = typename std::decay<decltype(arg)>::type;
+                Serializable<T>::serialize(arg, serializer);
+            },
+            value);
+    }
+};
+
+/* ---------- */
+
+template <typename T>
+struct Deserializable<std::unique_ptr<T>> {
+    template <typename Deserializer>
+    static std::unique_ptr<T> deserialize(Deserializer &deserializer) {
+        return std::make_unique<T>(
+            Deserializable<T>::deserialize(deserializer));
+    }
+};
+
+template <typename T, typename Allocator>
+struct Deserializable<std::vector<T, Allocator>> {
+    template <typename Deserializer>
+    static std::vector<T> deserialize(Deserializer &deserializer) {
+        std::vector<T> result;
+        uint32_t len = deserializer.deserialize_len();
+        for (uint32_t i = 0; i < len; i++) {
+            result.push_back(Deserializable<T>::deserialize(deserializer));
+        }
+        return result;
+    }
+};
+
+template <typename T, std::size_t N>
+struct Deserializable<std::array<T, N>> {
+    template <typename Deserializer>
+    static std::array<T, N> deserialize(Deserializer &deserializer) {
+        std::array<T, N> result;
+        for (T &item : result) {
+            item = Deserializable<T>::deserialize(deserializer);
+        }
+        return result;
+    }
+};
+
+template <>
+struct Deserializable<std::string> {
+    template <typename Deserializer>
+    static std::string deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_str();
+    }
+};
+
+template <>
+struct Deserializable<uint8_t> {
+    template <typename Deserializer>
+    static uint8_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u8();
+    }
+};
+
+template <>
+struct Deserializable<uint16_t> {
+    template <typename Deserializer>
+    static uint16_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u16();
+    }
+};
+
+template <>
+struct Deserializable<uint32_t> {
+    template <typename Deserializer>
+    static uint32_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u32();
+    }
+};
+
+template <>
+struct Deserializable<uint64_t> {
+    template <typename Deserializer>
+    static uint64_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u64();
+    }
+};
+
+template <>
+struct Deserializable<uint128_t> {
+    template <typename Deserializer>
+    static uint128_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u128();
+    }
+};
+
+template <>
+struct Deserializable<int8_t> {
+    template <typename Deserializer>
+    static int8_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i8();
+    }
+};
+
+template <>
+struct Deserializable<int16_t> {
+    template <typename Deserializer>
+    static int16_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i16();
+    }
+};
+
+template <>
+struct Deserializable<int32_t> {
+    template <typename Deserializer>
+    static int32_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i32();
+    }
+};
+
+template <>
+struct Deserializable<int64_t> {
+    template <typename Deserializer>
+    static int64_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i64();
+    }
+};
+
+template <>
+struct Deserializable<int128_t> {
+    template <typename Deserializer>
+    static int128_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i128();
+    }
+};
+
+// Must be defined after (u)int128_t.
+template <class... Types>
+struct Deserializable<std::tuple<Types...>> {
+    template <typename Deserializer>
+    static std::tuple<Types...> deserialize(Deserializer &deserializer) {
+        return std::make_tuple(
+            Deserializable<Types>::deserialize(deserializer)...);
+    }
+};
+
+template <class... Types>
+struct Deserializable<std::variant<Types...>> {
+    template <typename Deserializer>
+    static std::variant<Types...> deserialize(Deserializer &deserializer) {
+        auto index = deserializer.deserialize_variant_index();
+
+        using Case = std::function<std::variant<Types...>()>;
+
+        auto make_case = [&deserializer](auto tag) -> Case {
+            using T = typename decltype(tag)::type;
+            auto f = [&deserializer]() {
+                return std::variant<Types...>(
+                    Deserializable<T>::deserialize(deserializer));
+            };
+            return f;
+        };
+
+        std::array<Case, sizeof...(Types)> cases = {
+            make_case(std::common_type<Types>{})...};
+        return cases.at(index)();
+    }
+};

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -1,0 +1,313 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::analyzer;
+use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
+use std::collections::{BTreeMap, HashSet};
+use std::io::{Result, Write};
+
+// TODO:
+// * optional namespace
+// * optionally use `using` for newtype/tuple structs and variants, as well as enums
+
+pub fn output(
+    out: &mut dyn Write,
+    registry: &Registry,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    output_preambule(out)?;
+
+    let dependencies = analyzer::get_dependency_map(registry)?;
+    let entries = analyzer::best_effort_topological_sort(&dependencies);
+    let mut known_names = HashSet::new();
+    let mut known_sizes = HashSet::new();
+    for name in entries {
+        for dependency in &dependencies[name] {
+            if !known_names.contains(dependency) {
+                output_container_forward_definition(out, *dependency)?;
+                known_names.insert(*dependency);
+            }
+        }
+        let format = &registry[name];
+        output_container(out, name, format, &known_sizes)?;
+        known_sizes.insert(name);
+        known_names.insert(name);
+    }
+
+    writeln!(out)?;
+    for (name, format) in registry {
+        output_container_traits(out, name, format)?;
+    }
+    Ok(())
+}
+
+fn output_preambule(out: &mut dyn std::io::Write) -> Result<()> {
+    writeln!(out, "#include \"serde.hpp\"\n")
+}
+
+/// If known_sizes is present, we must try to return a type with a known size as well.
+fn quote_type(format: &Format, known_sizes: Option<&HashSet<&str>>, namespace: &str) -> String {
+    use Format::*;
+    match format {
+        TypeName(x) => {
+            if let Some(set) = known_sizes {
+                if !set.contains(x.as_str()) {
+                    return format!("std::unique_ptr<{}{}>", namespace, x);
+                }
+            }
+            format!("{}{}", namespace, x)
+        }
+        Unit => "std::monostate".into(),
+        Bool => "bool".into(),
+        I8 => "int8_t".into(),
+        I16 => "int16_t".into(),
+        I32 => "int32_t".into(),
+        I64 => "int64_t".into(),
+        I128 => "int128_t".into(),
+        U8 => "uint8_t".into(),
+        U16 => "uint16_t".into(),
+        U32 => "uint32_t".into(),
+        U64 => "uint64_t".into(),
+        U128 => "uint128_t".into(),
+        F32 => "float".into(),
+        F64 => "double".into(),
+        Char => "char".into(),
+        Str => "std::string".into(),
+        Bytes => "std::vector<uint8_t>".into(),
+
+        Option(format) => format!(
+            "std::optional<{}>",
+            quote_type(format, known_sizes, namespace)
+        ),
+        Seq(format) => format!("std::vector<{}>", quote_type(format, None, namespace)),
+        Map { key, value } => format!(
+            "std::map<{}, {}>",
+            quote_type(key, None, namespace),
+            quote_type(value, None, namespace)
+        ),
+        Tuple(formats) => format!(
+            "std::tuple<{}>",
+            quote_types(formats, known_sizes, namespace)
+        ),
+        TupleArray { content, size } => format!(
+            "std::array<{}, {}>",
+            quote_type(content, known_sizes, namespace),
+            *size
+        ),
+
+        Variable(_) => panic!("unexpected value"),
+    }
+}
+
+fn quote_types(formats: &[Format], known_sizes: Option<&HashSet<&str>>, namespace: &str) -> String {
+    formats
+        .iter()
+        .map(|x| quote_type(x, known_sizes, namespace))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn output_fields(
+    out: &mut dyn std::io::Write,
+    indentation: usize,
+    fields: &[Named<Format>],
+    known_sizes: &HashSet<&str>,
+    namespace: &str,
+) -> Result<()> {
+    let tab = " ".repeat(indentation);
+    for field in fields {
+        writeln!(
+            out,
+            "{}{} {};",
+            tab,
+            quote_type(&field.value, Some(known_sizes), namespace),
+            field.name
+        )?;
+    }
+    Ok(())
+}
+
+fn output_variant(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    variant: &VariantFormat,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    use VariantFormat::*;
+    match variant {
+        Unit => writeln!(out, "    struct {} {{}};", name),
+        NewType(format) => writeln!(
+            out,
+            "    struct {} {{\n        {} value;\n    }};",
+            name,
+            quote_type(format, Some(known_sizes), "::")
+        ),
+        Tuple(formats) => writeln!(
+            out,
+            "    struct {} {{\n        std::tuple<{}> value;\n    }};",
+            name,
+            quote_types(formats, Some(known_sizes), "::")
+        ),
+        Struct(fields) => {
+            writeln!(out, "    struct {} {{", name)?;
+            output_fields(out, 8, fields, known_sizes, "::")?;
+            writeln!(out, "    }};")
+        }
+        Variable(_) => panic!("incorrect value"),
+    }
+}
+
+fn output_variants(
+    out: &mut dyn std::io::Write,
+    variants: &BTreeMap<u32, Named<VariantFormat>>,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    for (expected_index, (index, variant)) in variants.iter().enumerate() {
+        assert_eq!(*index, expected_index as u32);
+        output_variant(out, &variant.name, &variant.value, known_sizes)?;
+    }
+    Ok(())
+}
+
+fn output_container_forward_definition(out: &mut dyn std::io::Write, name: &str) -> Result<()> {
+    writeln!(out, "struct {};\n", name)
+}
+
+fn output_container(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    format: &ContainerFormat,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    use ContainerFormat::*;
+    match format {
+        UnitStruct => writeln!(out, "struct {} {{}};\n", name),
+        NewTypeStruct(format) => writeln!(
+            out,
+            "struct {} {{\n    {} value;\n}};\n",
+            name,
+            quote_type(format, Some(known_sizes), ""),
+        ),
+        TupleStruct(formats) => writeln!(
+            out,
+            "struct {} {{\n    std::tuple<{}> value;\n}};\n",
+            name,
+            quote_types(formats, Some(known_sizes), ""),
+        ),
+        Struct(fields) => {
+            writeln!(out, "struct {} {{", name)?;
+            output_fields(out, 4, fields, known_sizes, "")?;
+            writeln!(out, "}};\n")
+        }
+        Enum(variants) => {
+            writeln!(out, "struct {} {{", name)?;
+            output_variants(out, variants, known_sizes)?;
+            writeln!(
+                out,
+                "    std::variant<{}> value;\n}};\n",
+                variants
+                    .iter()
+                    .map(|(_, v)| v.name.clone())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            )
+        }
+    }
+}
+
+fn output_struct_serializable(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    fields: &[&str],
+) -> Result<()> {
+    writeln!(
+        out,
+        r#"
+template <>
+template <typename Serializer>
+void Serializable<{}>::serialize(const {} &obj, Serializer &serializer) {{"#,
+        name, name,
+    )?;
+    for field in fields {
+        writeln!(
+            out,
+            "    Serializable<decltype(obj.{})>::serialize(obj.{}, serializer);",
+            field, field,
+        )?;
+    }
+    writeln!(out, "}}")
+}
+
+fn output_struct_deserializable(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    fields: &[&str],
+) -> Result<()> {
+    writeln!(
+        out,
+        r#"
+template <>
+template <typename Deserializer>
+{} Deserializable<{}>::deserialize(Deserializer &deserializer) {{
+    {} obj;"#,
+        name, name, name,
+    )?;
+    for field in fields {
+        writeln!(
+            out,
+            "    obj.{} = Deserializable<decltype(obj.{})>::deserialize(deserializer);",
+            field, field,
+        )?;
+    }
+    writeln!(out, "    return obj;\n}}")
+}
+
+fn output_struct_traits(out: &mut dyn std::io::Write, name: &str, fields: &[&str]) -> Result<()> {
+    output_struct_serializable(out, name, fields)?;
+    output_struct_deserializable(out, name, fields)
+}
+
+fn get_variant_fields(format: &VariantFormat) -> Vec<&str> {
+    use VariantFormat::*;
+    match format {
+        Unit => Vec::new(),
+        NewType(_format) => vec!["value"],
+        Tuple(_formats) => vec!["value"],
+        Struct(fields) => fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>(),
+        Variable(_) => panic!("incorrect value"),
+    }
+}
+
+fn output_container_traits(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    format: &ContainerFormat,
+) -> Result<()> {
+    use ContainerFormat::*;
+    match format {
+        UnitStruct => output_struct_traits(out, name, &[]),
+        NewTypeStruct(_format) => output_struct_traits(out, name, &["value"]),
+        TupleStruct(_formats) => output_struct_traits(out, name, &["value"]),
+        Struct(fields) => output_struct_traits(
+            out,
+            name,
+            &fields
+                .iter()
+                .map(|field| field.name.as_str())
+                .collect::<Vec<_>>(),
+        ),
+        Enum(variants) => {
+            output_struct_traits(out, name, &["value"])?;
+            for variant in variants.values() {
+                output_struct_traits(
+                    out,
+                    &format!("{}::{}", name, variant.name),
+                    &get_variant_fields(&variant.value),
+                )?;
+            }
+            Ok(())
+        }
+    }
+}

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -7,7 +7,7 @@
 //! cargo run -p serde-generate -- --help
 //! '''
 
-use serde_generate::{python3, rust};
+use serde_generate::{cpp, python3, rust};
 use serde_reflection::Registry;
 use std::path::PathBuf;
 use structopt::{clap::arg_enum, StructOpt};
@@ -16,6 +16,7 @@ arg_enum! {
 #[derive(Debug, StructOpt)]
 enum Language {
     Python3,
+    Cpp,
     Rust,
 }
 }
@@ -43,6 +44,7 @@ fn main() {
 
     match options.language {
         Language::Python3 => python3::output(&mut out, &registry).unwrap(),
+        Language::Cpp => cpp::output(&mut out, &registry).unwrap(),
         Language::Rust => rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap(),
     }
 }

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -7,7 +7,7 @@
 //! cargo run -p serde-generate -- --help
 //! '''
 
-use serde_generate::{cpp, python3, rust};
+use serde_generate::{cpp, java, python3, rust};
 use serde_reflection::Registry;
 use std::path::PathBuf;
 use structopt::{clap::arg_enum, StructOpt};
@@ -18,6 +18,7 @@ enum Language {
     Python3,
     Cpp,
     Rust,
+    Java,
 }
 }
 
@@ -46,5 +47,6 @@ fn main() {
         Language::Python3 => python3::output(&mut out, &registry).unwrap(),
         Language::Cpp => cpp::output(&mut out, &registry).unwrap(),
         Language::Rust => rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap(),
+        Language::Java => java::output(&mut out, &registry).unwrap(),
     }
 }

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -1,0 +1,203 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
+use std::collections::BTreeMap;
+use std::io::{Result, Write};
+
+pub fn output(out: &mut dyn Write, registry: &Registry) -> Result<()> {
+    output_preambule(out)?;
+
+    writeln!(out, "public class Test {{")?;
+    writeln!(
+        out,
+        r#"
+public static class Unit {{}};
+public static class Tuple2<T1, T2> {{ public T1 field1; public T2 field2; }};
+public static class Tuple3<T1, T2, T3> {{ public T1 field1; public T2 field2; public T3 field3; }};
+public static class Tuple4<T1, T2, T3, T4> {{ public T1 field1; public T2 field2; public T3 field3; public T4 field4; }};
+public static class Integer128 {{ public Long high; public Long low; }};
+"#
+    )?;
+    for (name, format) in registry {
+        output_container(out, name, format)?;
+    }
+    writeln!(out, "}}")
+}
+
+fn output_preambule(out: &mut dyn Write) -> Result<()> {
+    writeln!(
+        out,
+        r#"
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Vector;
+import java.util.SortedMap;
+import java.lang.Class;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({{ElementType.TYPE_USE}})
+@interface Unsigned {{}}
+
+@Target({{ElementType.TYPE_USE}})
+@interface FixedLength {{
+    int length();
+}}
+
+@Target({{ElementType.TYPE_USE}})
+@interface Enum {{
+    Class<?>[] variants();
+}}
+
+@Target({{ElementType.TYPE_USE}})
+@interface Variant {{
+    long index();
+}}
+"#
+    )
+}
+
+fn quote_type(format: &Format) -> String {
+    use Format::*;
+    match format {
+        TypeName(x) => x.to_string(),
+        Unit => "Unit".into(),
+        Bool => "Boolean".into(),
+        I8 => "Byte".into(),
+        I16 => "Short".into(),
+        I32 => "Integer".into(),
+        I64 => "Long".into(),
+        I128 => "Integer128".into(),
+        U8 => "@Unsigned Byte".into(),
+        U16 => "@Unsigned Short".into(),
+        U32 => "@Unsigned Integer".into(),
+        U64 => "@Unsigned Long".into(),
+        U128 => "@Unsigned Integer128".into(),
+        F32 => "Float".into(),
+        F64 => "Double".into(),
+        Char => "Character".into(),
+        Str => "String".into(),
+        Bytes => "ByteBuffer".into(),
+
+        Option(format) => format!("Optional<{}>", quote_type(format)),
+        Seq(format) => format!("Vector<{}>", quote_type(format)),
+        Map { key, value } => format!("SortedMap<{}, {}>", quote_type(key), quote_type(value)),
+        Tuple(formats) => format!("Tuple{}<{}>", formats.len(), quote_types(formats)),
+        TupleArray { content, size } => format!(
+            "@FixedLength(length={}) Vector<{}>",
+            size,
+            quote_type(content)
+        ),
+        Variable(_) => panic!("unexpected value"),
+    }
+}
+
+fn quote_types(formats: &[Format]) -> String {
+    formats
+        .iter()
+        .map(quote_type)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn output_fields(out: &mut dyn Write, indentation: usize, fields: &[Named<Format>]) -> Result<()> {
+    let tab = " ".repeat(indentation);
+    for field in fields {
+        writeln!(
+            out,
+            "{} public {} {};",
+            tab,
+            quote_type(&field.value),
+            field.name
+        )?;
+    }
+    Ok(())
+}
+
+fn output_variant(
+    out: &mut dyn Write,
+    base: &str,
+    name: &str,
+    index: u32,
+    variant: &VariantFormat,
+) -> Result<()> {
+    use VariantFormat::*;
+    let annotation = format!("@Variant(index = {})\n", index);
+    let class = format!("public static class {}_{} extends {}", base, name, base);
+    match variant {
+        Unit => writeln!(out, "\n{}{} {{}};", annotation, class),
+        NewType(format) => writeln!(
+            out,
+            "\n{}{} {{\n    {} value;\n}};",
+            annotation,
+            class,
+            quote_type(format),
+        ),
+        Tuple(formats) => writeln!(
+            out,
+            "\n{}{} {{\n    {} value;\n}};",
+            annotation,
+            class,
+            quote_type(&Format::Tuple(formats.clone())),
+        ),
+        Struct(fields) => {
+            writeln!(out, "\n{}{} {{", annotation, class)?;
+            output_fields(out, 4, fields)?;
+            writeln!(out, "}};")
+        }
+        Variable(_) => panic!("incorrect value"),
+    }
+}
+
+fn output_variants(
+    out: &mut dyn Write,
+    base: &str,
+    variants: &BTreeMap<u32, Named<VariantFormat>>,
+) -> Result<()> {
+    for (index, variant) in variants {
+        output_variant(out, base, &variant.name, *index, &variant.value)?;
+    }
+    Ok(())
+}
+
+fn output_container(out: &mut dyn Write, name: &str, format: &ContainerFormat) -> Result<()> {
+    use ContainerFormat::*;
+    match format {
+        UnitStruct => writeln!(out, "public static class {} {{}};\n", name),
+        NewTypeStruct(format) => writeln!(
+            out,
+            "public static class {} {{\n    {} value;\n}};\n",
+            name,
+            quote_type(format)
+        ),
+        TupleStruct(formats) => writeln!(
+            out,
+            "public static class {} {{\n    {} value;\n}};\n",
+            name,
+            quote_type(&Format::Tuple(formats.clone()))
+        ),
+        Struct(fields) => {
+            writeln!(out, "public static class {} {{", name)?;
+            output_fields(out, 4, fields)?;
+            writeln!(out, "}};\n")
+        }
+        Enum(variants) => {
+            writeln!(
+                out,
+                r#"@Enum(variants={{
+    {}
+}})
+public abstract static class {} {{}};
+"#,
+                variants
+                    .iter()
+                    .map(|(_, v)| format!("{}_{}.class", name, v.name))
+                    .collect::<Vec<_>>()
+                    .join(",\n    "),
+                name
+            )?;
+            output_variants(out, name, variants)
+        }
+    }
+}

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -5,10 +5,12 @@
 //!
 //! Supported languages:
 //! * C++ 17
+//! * Java 8
 //! * Python 3
 //! * Rust 2018
 
 pub mod analyzer;
 pub mod cpp;
+pub mod java;
 pub mod python3;
 pub mod rust;

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -4,9 +4,11 @@
 //! # Serde code-generation library (experimental)
 //!
 //! Supported languages:
+//! * C++ 17
 //! * Python 3
 //! * Rust 2018
 
 pub mod analyzer;
+pub mod cpp;
 pub mod python3;
 pub mod rust;

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use serde_generate::{cpp, python3, rust};
+use serde_generate::{cpp, java, python3, rust};
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;
@@ -46,6 +46,19 @@ fn test_that_cpp_code_compiles() {
         .arg(source_path)
         .output()
         .unwrap();
+    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}
+
+#[test]
+fn test_that_java_code_compiles() {
+    let registry = test_utils::get_registry().unwrap();
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("Test.java");
+    let mut source = File::create(&source_path).unwrap();
+    java::output(&mut source, &registry).unwrap();
+
+    let output = Command::new("javac").arg(source_path).output().unwrap();
     assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
     assert!(output.status.success());
 }

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use serde_generate::{python3, rust};
+use serde_generate::{cpp, python3, rust};
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;
@@ -22,6 +22,28 @@ fn test_that_python_code_parses() {
     let output = Command::new("python3")
         .arg(source_path)
         .env("PYTHONPATH", python_path)
+        .output()
+        .unwrap();
+    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}
+
+#[test]
+fn test_that_cpp_code_compiles() {
+    let registry = test_utils::get_registry().unwrap();
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("test.cpp");
+    let mut source = File::create(&source_path).unwrap();
+    cpp::output(&mut source, &registry).unwrap();
+
+    let output = Command::new("clang++")
+        .arg("--std=c++17")
+        .arg("-c")
+        .arg("-o")
+        .arg(dir.path().join("test.o"))
+        .arg("-I")
+        .arg("runtime/cpp")
+        .arg(source_path)
         .output()
         .unwrap();
     assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));


### PR DESCRIPTION
# Summary

This draft PR demonstrates further support for code generation in
* C++17,
* Java8,

# Test plan

```
cargo test

# test a particular language like this:
cargo run -p serde-generate -- --language java <(curl https://raw.githubusercontent.com/libra/libra/master/testsuite/generate-format/tests/staged/libra.yaml)
```