### PR TITLE
[serde-reflection] support recursive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "serde-reflection"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "serde",

--- a/serde-reflection/Cargo.toml
+++ b/serde-reflection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-reflection"
-version = "0.1.0"
+version = "0.2.0"
 description = "Extract representations of Serde data formats"
 documentation = "https://docs.rs/serde-reflection"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-reflection/README.md
+++ b/serde-reflection/README.md
@@ -231,9 +231,6 @@ The first 4 cases are what we have called *possible recursion points* above:
 * while visiting an `enum T` for the second time, we choose to return the first variant, i.e.
 a "base case" by assumption (1) above.
 
-TODO ([#5](https://github.com/facebookincubator/serde-reflection/issues/5)): the detection of
-"the second time" above is currently only effective for enums.
-
 In addition to the cases above,
 
 * while visiting a container, if the container's name is mapped to a recorded value,

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -298,6 +298,6 @@ mod trace;
 mod value;
 
 pub use error::{Error, Result};
-pub use format::{ContainerFormat, Format, FormatHolder, Named, VariantFormat};
+pub use format::{ContainerFormat, Format, FormatHolder, Named, Variable, VariantFormat};
 pub use trace::{Registry, RegistryOwned, Samples, Tracer, TracerConfig};
 pub use value::Value;

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -275,9 +275,6 @@
 //! * while visiting an `enum T` for the second time, we choose to return the first variant, i.e.
 //! a "base case" by assumption (1) above.
 //!
-//! TODO ([#5](https://github.com/facebookincubator/serde-reflection/issues/5)): the detection of
-//! "the second time" above is currently only effective for enums.
-//!
 //! In addition to the cases above,
 //!
 //! * while visiting a container, if the container's name is mapped to a recorded value,

--- a/serde-reflection/src/ser.rs
+++ b/serde-reflection/src/ser.rs
@@ -99,7 +99,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
     }
 
     fn serialize_none(self) -> Result<(Format, Value)> {
-        Ok((Format::Unknown, Value::Option(None)))
+        Ok((Format::unknown(), Value::Option(None)))
     }
 
     fn serialize_some<T>(self, v: &T) -> Result<(Format, Value)>
@@ -182,7 +182,7 @@ impl<'a> ser::Serializer for Serializer<'a> {
         Ok(SeqSerializer {
             tracer: self.tracer,
             samples: self.samples,
-            format: Format::Unknown,
+            format: Format::unknown(),
             values: Vec::new(),
         })
     }
@@ -232,8 +232,8 @@ impl<'a> ser::Serializer for Serializer<'a> {
         Ok(MapSerializer {
             tracer: self.tracer,
             samples: self.samples,
-            key_format: Format::Unknown,
-            value_format: Format::Unknown,
+            key_format: Format::unknown(),
+            value_format: Format::unknown(),
             values: Vec::new(),
         })
     }

--- a/serde-reflection/src/trace.rs
+++ b/serde-reflection/src/trace.rs
@@ -120,7 +120,9 @@ impl Tracer {
         T: ?Sized + Serialize,
     {
         let serializer = Serializer::new(self, samples);
-        value.serialize(serializer)
+        let (mut format, sample) = value.serialize(serializer)?;
+        format.reduce();
+        Ok((format, sample))
     }
 
     /// Trace a single deserialization of a particular type.
@@ -135,9 +137,10 @@ impl Tracer {
     where
         T: Deserialize<'de>,
     {
-        let mut format = Format::Unknown;
+        let mut format = Format::unknown();
         let deserializer = Deserializer::new(self, samples, &mut format);
         let value = T::deserialize(deserializer)?;
+        format.reduce();
         Ok((format, value))
     }
 
@@ -150,9 +153,10 @@ impl Tracer {
     where
         S: DeserializeSeed<'de>,
     {
-        let mut format = Format::Unknown;
+        let mut format = Format::unknown();
         let deserializer = Deserializer::new(self, samples, &mut format);
         let value = seed.deserialize(deserializer)?;
+        format.reduce();
         Ok((format, value))
     }
 

--- a/serde-reflection/tests/format.rs
+++ b/serde-reflection/tests/format.rs
@@ -35,28 +35,29 @@ fn test_format_visiting() {
         .unwrap();
     assert_eq!(names.len(), 2);
 
-    assert!(VariantFormat::Unknown.visit(&mut |_| Ok(())).is_err());
-    assert!(Format::Unknown.visit(&mut |_| Ok(())).is_err());
+    assert!(VariantFormat::unknown().visit(&mut |_| Ok(())).is_err());
+    assert!(Format::unknown().visit(&mut |_| Ok(())).is_err());
 }
 
 #[test]
 fn test_format_unification() {
     use Format::*;
 
-    let mut x = Unknown;
+    let mut x = Format::unknown();
     assert!(x.unify(U8).is_ok());
+    x.reduce();
     assert_eq!(x, U8);
     assert_eq!(
         x.unify(U16).unwrap_err(),
         Error::Incompatible("U8".into(), "U16".into())
     );
 
-    let mut x = Tuple(vec![Unknown, U32]);
-    x.unify(Tuple(vec![U16, Unknown])).unwrap();
+    let mut x = Tuple(vec![Format::unknown(), U32]);
+    x.unify(Tuple(vec![U16, Format::unknown()])).unwrap();
+    x.reduce();
     assert_eq!(x, Tuple(vec![U16, U32]));
 
     for x in vec![
-        Unknown,
         Unit,
         Bool,
         I8,
@@ -81,15 +82,14 @@ fn test_format_unification() {
             key: Box::new(Unit),
             value: Box::new(Unit),
         },
-        Tuple(vec![Unknown]),
+        Tuple(vec![Format::unknown()]),
     ]
     .iter_mut()
     {
-        assert!(x.unify(x.clone()).is_ok());
-        assert_eq!(*x != Unknown, x.unify(TypeName("bar".into())).is_err());
-        assert_eq!(*x != Unknown, x.unify(Option(Box::new(U32))).is_err());
-        assert_eq!(*x != Unknown, x.unify(Seq(Box::new(U32))).is_err());
-        assert_eq!(*x != Unknown, x.unify(Tuple(vec![])).is_err());
+        assert!(x.unify(TypeName("bar".into())).is_err());
+        assert!(x.unify(Option(Box::new(U32))).is_err());
+        assert!(x.unify(Seq(Box::new(U32))).is_err());
+        assert!(x.unify(Tuple(vec![])).is_err());
     }
 }
 
@@ -98,8 +98,9 @@ fn test_container_format_unification() {
     use ContainerFormat::*;
     use Format::*;
 
-    let mut x = TupleStruct(vec![Unknown, U32]);
-    x.unify(TupleStruct(vec![U16, Unknown])).unwrap();
+    let mut x = TupleStruct(vec![Format::unknown(), U32]);
+    x.unify(TupleStruct(vec![U16, Format::unknown()])).unwrap();
+    x.reduce();
     assert_eq!(x, TupleStruct(vec![U16, U32]));
 
     let mut x = Enum(
@@ -107,7 +108,7 @@ fn test_container_format_unification() {
             0,
             Named {
                 name: "foo".into(),
-                value: VariantFormat::Tuple(vec![Unknown]),
+                value: VariantFormat::Tuple(vec![Format::unknown()]),
             },
         )]
         .into_iter()
@@ -139,35 +140,21 @@ fn test_container_format_unification() {
             .collect()
         ))
         .is_ok());
-    // We don't check for name collisions in variants.
-    assert!(x
-        .unify(Enum(
-            vec![(
-                1,
-                Named {
-                    name: "foo".into(),
-                    value: VariantFormat::Unknown
-                }
-            )]
-            .into_iter()
-            .collect()
-        ))
-        .is_ok());
 
     for x in vec![
         UnitStruct,
         NewTypeStruct(Box::new(Unit)),
-        TupleStruct(vec![Unknown]),
+        TupleStruct(vec![Format::unknown()]),
         Struct(vec![Named {
             name: "foo".into(),
-            value: Unknown,
+            value: Format::unknown(),
         }]),
         Enum(
             vec![(
                 0,
                 Named {
                     name: "foo".into(),
-                    value: VariantFormat::Unknown,
+                    value: VariantFormat::unknown(),
                 },
             )]
             .into_iter()
@@ -176,13 +163,12 @@ fn test_container_format_unification() {
     ]
     .iter_mut()
     {
-        assert!(x.unify(x.clone()).is_ok());
         assert!(x.unify(NewTypeStruct(Box::new(U8))).is_err());
         assert!(x.unify(TupleStruct(vec![])).is_err());
         assert!(x
             .unify(Struct(vec![Named {
                 name: "bar".into(),
-                value: Unknown
+                value: Format::unknown()
             }]))
             .is_err());
         assert!(x
@@ -191,7 +177,7 @@ fn test_container_format_unification() {
                     0,
                     Named {
                         name: "bar".into(),
-                        value: VariantFormat::Unknown
+                        value: VariantFormat::unknown()
                     }
                 )]
                 .into_iter()


### PR DESCRIPTION
## Summary

This PR aims to address #5 by introducing a more powerful unification algorithm with proper variables and term-sharing.

## Test Plan

included unit tests