### PR TITLE
[serde-name] New minimal library to extract serde names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-name"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde-reflection",
+ "thiserror",
+]
+
+[[package]]
 name = "serde-reflection"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "serde-name",
     "serde-reflection",
 ]
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This repository contains the source code for:
 
 * [`serde-reflection`](serde-reflection): a library to extract and represent Serde data formats [![serde-reflection on crates.io](https://img.shields.io/crates/v/serde-reflection)](https://crates.io/crates/serde-reflection) [![Documentation (latest release)](https://docs.rs/serde-reflection/badge.svg)](https://docs.rs/serde-reflection/) [![Documentation (master)](https://img.shields.io/badge/docs-master-59f)](https://facebookincubator.github.io/serde-reflection/serde_reflection/)
 
+* [`serde-name`](serde-name): a minimal library meant to quickly compute the Serde name of Rust structs and enums [![serde-name on crates.io](https://img.shields.io/crates/v/serde-name)](https://crates.io/crates/serde-name) [![Documentation (latest release)](https://docs.rs/serde-name/badge.svg)](https://docs.rs/serde-name/) [![Documentation (master)](https://img.shields.io/badge/docs-master-59f)](https://facebookincubator.github.io/serde-reflection/serde_name/)
+
 The code in this repository is under active development.
 
 ## Use cases
@@ -23,6 +25,8 @@ This project aims to facilitate the implementation of distributed protocols and 
 In addition to ensuring an optimal developer experience in Rust, the approach based on Serde and `serde-reflection` empowers protocol designers to experiment and choose the best encoding format for their data: either [one of the encoding formats](https://serde.rs/#data-formats) officially supported by Serde, or [a new encoding format](https://serde.rs/data-format.html) developed in the Serde framework.
 
 This project was initially motivated by the need for canonical serialization and cryptographic hashing in the [Libra](https://github.com/libra/libra) project.
+
+In this context, `serde-name` has been used to provide predictable cryptographic seeds for Rust containers.
 
 ## Contributing
 

--- a/serde-name/Cargo.toml
+++ b/serde-name/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "serde-name"
+version = "0.1.0"
+description = "Extract the Serde name of structs and enums"
+documentation = "https://docs.rs/serde-name"
+repository = "https://github.com/facebookincubator/serde-reflection"
+authors = ["Mathieu Baudet <mathieubaudet@calibra.com>", "Brandon Williams <bmwill@calibra.com>"]
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+keywords = ["data-structures", "serialization", "serde"]
+categories = ["encoding", "development-tools"]
+edition = "2018"
+exclude = [
+    # Readme template that doesn't need to be included.
+    "README.tpl",
+]
+
+[dependencies]
+thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+
+[dev-dependencies]
+serde-reflection = { path = "../serde-reflection", version = "0.2.0" }

--- a/serde-name/README.md
+++ b/serde-name/README.md
@@ -1,0 +1,39 @@
+# serde-name
+
+[![serde-name on crates.io](https://img.shields.io/crates/v/serde-name)](https://crates.io/crates/serde-name)
+[![Documentation (latest release)](https://docs.rs/serde-name/badge.svg)](https://docs.rs/serde-name/)
+[![Documentation (master)](https://img.shields.io/badge/docs-master-brightgreen)](https://facebookincubator.github.io/serde-reflection/serde_name/)
+[![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
+
+This crate provides a fast and reliable way to extract the Serde name of a Rust container.
+
+```rust
+#[derive(Deserialize)]
+struct Foo {
+  bar: Bar,
+}
+
+#[derive(Deserialize)]
+#[serde(rename = "ABC")]
+enum Bar { A, B, C }
+
+assert_eq!(trace_name::<Foo>(), Some("Foo"));
+assert_eq!(trace_name::<Bar>(), Some("ABC"));
+assert_eq!(trace_name::<Option<Bar>>(), None);
+```
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of either the [Apache 2.0 license](../LICENSE-APACHE) or the [MIT license](../LICENSE-MIT).
+
+<!--
+README.md is generated from README.tpl by cargo readme. To regenerate:
+
+cargo install cargo-readme
+cargo readme > README.md
+-->

--- a/serde-name/README.tpl
+++ b/serde-name/README.tpl
@@ -1,0 +1,24 @@
+# {{crate}}
+
+[![serde-name on crates.io](https://img.shields.io/crates/v/serde-name)](https://crates.io/crates/serde-name)
+[![Documentation (latest release)](https://docs.rs/serde-name/badge.svg)](https://docs.rs/serde-name/)
+[![Documentation (master)](https://img.shields.io/badge/docs-master-brightgreen)](https://facebookincubator.github.io/serde-reflection/serde_name/)
+[![License](https://img.shields.io/badge/license-Apache-green.svg)](../LICENSE-APACHE)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](../LICENSE-MIT)
+
+{{readme}}
+
+## Contributing
+
+See the [CONTRIBUTING](../CONTRIBUTING.md) file for how to help out.
+
+## License
+
+This project is available under the terms of either the [Apache 2.0 license](../LICENSE-APACHE) or the [MIT license](../LICENSE-MIT).
+
+<!--
+README.md is generated from README.tpl by cargo readme. To regenerate:
+
+cargo install cargo-readme
+cargo readme > README.md
+-->

--- a/serde-name/src/lib.rs
+++ b/serde-name/src/lib.rs
@@ -1,0 +1,167 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#![forbid(unsafe_code)]
+
+//! This crate provides a fast and reliable way to extract the Serde name of a Rust container.
+//!
+//! ```rust
+//! # use serde::Deserialize;
+//! # use serde_name::trace_name;
+//! #[derive(Deserialize)]
+//! struct Foo {
+//!   bar: Bar,
+//! }
+//!
+//! #[derive(Deserialize)]
+//! #[serde(rename = "ABC")]
+//! enum Bar { A, B, C }
+//!
+//! assert_eq!(trace_name::<Foo>(), Some("Foo"));
+//! assert_eq!(trace_name::<Bar>(), Some("ABC"));
+//! assert_eq!(trace_name::<Option<Bar>>(), None);
+//! ```
+
+use serde::de::Visitor;
+use thiserror::Error;
+
+/// Compute the Serde name of a container.
+pub fn trace_name<'de, T>() -> Option<&'static str>
+where
+    T: serde::de::Deserialize<'de>,
+{
+    match T::deserialize(SerdeName) {
+        Err(SerdeNameError(name)) => name,
+        _ => unreachable!(),
+    }
+}
+
+/// Minimal instrumented implementation of `serde::de::Deserializer`
+/// This always returns a `SerdeNameError` as soon as we have learnt the name
+/// of the type (or the absence of name) from Serde.
+struct SerdeName;
+
+/// Custom error value used to report the result of the analysis.
+#[derive(Clone, Debug, Error, PartialEq)]
+#[error("{0:?}")]
+struct SerdeNameError(Option<&'static str>);
+
+impl serde::de::Error for SerdeNameError {
+    fn custom<T: std::fmt::Display>(_msg: T) -> Self {
+        unreachable!();
+    }
+}
+
+macro_rules! declare_deserialize {
+    ($method:ident) => {
+        fn $method<V>(self, _visitor: V) -> std::result::Result<V::Value, SerdeNameError>
+        where
+            V: Visitor<'de>,
+        {
+            Err(SerdeNameError(None))
+        }
+    };
+}
+
+impl<'de> serde::de::Deserializer<'de> for SerdeName {
+    type Error = SerdeNameError;
+
+    declare_deserialize!(deserialize_any);
+    declare_deserialize!(deserialize_identifier);
+    declare_deserialize!(deserialize_ignored_any);
+    declare_deserialize!(deserialize_bool);
+    declare_deserialize!(deserialize_i8);
+    declare_deserialize!(deserialize_i16);
+    declare_deserialize!(deserialize_i32);
+    declare_deserialize!(deserialize_i64);
+    declare_deserialize!(deserialize_i128);
+    declare_deserialize!(deserialize_u8);
+    declare_deserialize!(deserialize_u16);
+    declare_deserialize!(deserialize_u32);
+    declare_deserialize!(deserialize_u64);
+    declare_deserialize!(deserialize_u128);
+    declare_deserialize!(deserialize_f32);
+    declare_deserialize!(deserialize_f64);
+    declare_deserialize!(deserialize_char);
+    declare_deserialize!(deserialize_str);
+    declare_deserialize!(deserialize_string);
+    declare_deserialize!(deserialize_bytes);
+    declare_deserialize!(deserialize_byte_buf);
+    declare_deserialize!(deserialize_option);
+    declare_deserialize!(deserialize_unit);
+    declare_deserialize!(deserialize_seq);
+    declare_deserialize!(deserialize_map);
+
+    fn deserialize_tuple<V>(
+        self,
+        _len: usize,
+        _visitor: V,
+    ) -> std::result::Result<V::Value, SerdeNameError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeNameError(None))
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        name: &'static str,
+        _visitor: V,
+    ) -> std::result::Result<V::Value, SerdeNameError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeNameError(Some(name)))
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        name: &'static str,
+        _visitor: V,
+    ) -> std::result::Result<V::Value, SerdeNameError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeNameError(Some(name)))
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> std::result::Result<V::Value, SerdeNameError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeNameError(Some(name)))
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> std::result::Result<V::Value, SerdeNameError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeNameError(Some(name)))
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> std::result::Result<V::Value, SerdeNameError>
+    where
+        V: Visitor<'de>,
+    {
+        Err(SerdeNameError(Some(name)))
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
+}

--- a/serde-name/tests/serde_name.rs
+++ b/serde-name/tests/serde_name.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde::{de::DeserializeOwned, Deserialize};
+use serde_reflection::{Format, FormatHolder, Samples, Tracer, TracerConfig};
+
+#[derive(Deserialize)]
+enum E {
+    Unit,
+}
+
+#[derive(Deserialize)]
+struct Unit;
+
+#[derive(Deserialize)]
+struct NewType(u64);
+
+#[derive(Deserialize)]
+struct Tuple(u64, u32);
+
+#[derive(Deserialize)]
+#[serde(rename = "FooStruct")]
+#[allow(dead_code)]
+struct Struct {
+    a: u64,
+}
+
+fn test_type<T>(expected_name: &'static str)
+where
+    T: DeserializeOwned,
+{
+    // this crate
+    assert_eq!(serde_name::trace_name::<T>(), Some(expected_name));
+
+    // serde-reflection
+    let mut tracer = Tracer::new(TracerConfig::default());
+    let samples = Samples::new();
+    let (mut ident, _samples) = tracer.trace_type::<T>(&samples).unwrap();
+    ident.normalize().unwrap();
+    assert_eq!(ident, Format::TypeName(expected_name.into()));
+}
+
+#[test]
+fn test_serde_name_and_reflection() {
+    test_type::<E>("E");
+    test_type::<Unit>("Unit");
+    test_type::<NewType>("NewType");
+    test_type::<Tuple>("Tuple");
+    test_type::<Struct>("FooStruct");
+
+    assert_eq!(serde_name::trace_name::<u64>(), None);
+    assert_eq!(serde_name::trace_name::<(E, E)>(), None);
+}


### PR DESCRIPTION
## Summary

The goal of this crate is to provide a minimal library that can be used at runtime for cryptographic use cases (e.g. seeding hash functions in a predictable way).

## Test Plan

```
cargo test
```