### PR TITLE
Use String rather than &'static str in Registry

### DIFF
--- a/serde-reflection/src/de.rs
+++ b/serde-reflection/src/de.rs
@@ -220,7 +220,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
         self.format.unify(Format::TypeName(name.into()))?;
         self.tracer
             .registry
-            .entry(name)
+            .entry(name.to_string())
             .unify(ContainerFormat::UnitStruct)?;
         visitor.visit_unit()
     }
@@ -249,7 +249,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
         let mut format = Format::unknown();
         self.tracer
             .registry
-            .entry(name)
+            .entry(name.to_string())
             .unify(ContainerFormat::NewTypeStruct(Box::new(format.clone())))?;
         // Compute the format.
         let inner = Deserializer::new(self.tracer, self.samples, &mut format);
@@ -312,7 +312,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
         let mut formats: Vec<_> = std::iter::repeat_with(Format::unknown).take(len).collect();
         self.tracer
             .registry
-            .entry(name)
+            .entry(name.to_string())
             .unify(ContainerFormat::TupleStruct(formats.clone()))?;
         // Compute the formats.
         let inner = SeqDeserializer::new(self.tracer, self.samples, formats.iter_mut());
@@ -378,7 +378,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
             .collect();
         self.tracer
             .registry
-            .entry(name)
+            .entry(name.to_string())
             .unify(ContainerFormat::Struct(formats.clone()))?;
         // Compute the formats.
         let inner = SeqDeserializer::new(
@@ -404,7 +404,7 @@ impl<'de, 'a> de::Deserializer<'de> for Deserializer<'de, 'a> {
         // Pre-update the registry.
         self.tracer
             .registry
-            .entry(name)
+            .entry(name.to_string())
             .unify(ContainerFormat::Enum(BTreeMap::new()))?;
         let known_variants = match self.tracer.registry.get_mut(name) {
             Some(ContainerFormat::Enum(x)) => x,

--- a/serde-reflection/src/error.rs
+++ b/serde-reflection/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     #[error("Incomplete tracing detected")]
     UnknownFormat,
     #[error("Incomplete tracing detected inside container: {0}")]
-    UnknownFormatInContainer(&'static str),
+    UnknownFormatInContainer(String),
     #[error("Missing variants detected for specific enums")]
     MissingVariants(Vec<String>),
 }

--- a/serde-reflection/src/lib.rs
+++ b/serde-reflection/src/lib.rs
@@ -216,7 +216,7 @@
 //! let mut tracer = Tracer::new(TracerConfig::default());
 //! let mut samples = Samples::new();
 //! tracer.trace_value(&mut samples, &FullName { first: "", middle: None, last: "" })?;
-//! assert_eq!(tracer.registry().unwrap_err(), Error::UnknownFormatInContainer("FullName"));
+//! assert_eq!(tracer.registry().unwrap_err(), Error::UnknownFormatInContainer("FullName".to_string()));
 //! # Ok(())
 //! # }
 //! ```
@@ -296,5 +296,5 @@ mod value;
 
 pub use error::{Error, Result};
 pub use format::{ContainerFormat, Format, FormatHolder, Named, Variable, VariantFormat};
-pub use trace::{Registry, RegistryOwned, Samples, Tracer, TracerConfig};
+pub use trace::{Registry, Samples, Tracer, TracerConfig};
 pub use value::Value;

--- a/serde-reflection/src/trace.rs
+++ b/serde-reflection/src/trace.rs
@@ -12,10 +12,7 @@ use serde::{de::DeserializeSeed, Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// A map of container formats.
-pub type Registry = BTreeMap<&'static str, ContainerFormat>;
-
-/// Similar to `Registry` but compatible with `serde::de::DeserializeOwned`.
-pub type RegistryOwned = BTreeMap<String, ContainerFormat>;
+pub type Registry = BTreeMap<String, ContainerFormat>;
 
 /// Structure to drive the tracing of Serde serialization and deserialization.
 /// This typically aims at computing a `Registry`.
@@ -217,7 +214,7 @@ impl Tracer {
         for (name, format) in registry.iter_mut() {
             format
                 .normalize()
-                .map_err(|_| Error::UnknownFormatInContainer(name))?;
+                .map_err(|_| Error::UnknownFormatInContainer(name.clone()))?;
         }
         if self.incomplete_enums.is_empty() {
             Ok(registry)
@@ -246,7 +243,7 @@ impl Tracer {
         value: Value,
         record_value: bool,
     ) -> Result<(Format, Value)> {
-        self.registry.entry(name).unify(format)?;
+        self.registry.entry(name.to_string()).unify(format)?;
         if record_value {
             samples.values.insert(name, value.clone());
         }


### PR DESCRIPTION
What I'm trying to do with serde-reflection (providing a proc-macro alternative to generate `ContainerFormat`) does not work if the key of BTreeMap has to be `'static`.