### PR TITLE
[serde generate] add support for rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "hex",
+ "maplit",
  "serde",
  "serde-reflection",
  "serde_bytes",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -27,6 +27,7 @@ serde_bytes = "0.11.3"
 tempfile = "3.1"
 bincode = "1.2"
 hex = "0.4.2"
+maplit = "1.0.2"
 
 test-utils = { path = "test_utils", version = "0.1.0" }
 

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -10,6 +10,7 @@
 
 Supported languages:
 * Python 3
+* Rust 2018
 
 ## Contributing
 

--- a/serde-generate/src/analyzer.rs
+++ b/serde-generate/src/analyzer.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde_reflection::{ContainerFormat, Format, FormatHolder, Registry, Result};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+fn get_dependencies(format: &ContainerFormat) -> Result<BTreeSet<&str>> {
+    let mut result = BTreeSet::new();
+    format.visit(&mut |format| {
+        if let Format::TypeName(x) = format {
+            result.insert(x.as_str());
+        }
+        Ok(())
+    })?;
+    Ok(result)
+}
+
+/// Build a map of dependencies between the entries of a `Registry`.
+/// * By definition, an entry named `x` depends on `y` iff the container format of `x` in the registry
+/// syntactically contains a reference to `y` (i.e. an expression `Format::TypeName(y)`).
+/// * Dependencies can play a role in code generation in some languages (e.g. Rust or C++) where inductive
+/// definitions may require explicit "boxing" (i.e. adding pointer indirections) to ensure finite object sizes.
+pub fn get_dependency_map(registry: &Registry) -> Result<BTreeMap<&str, BTreeSet<&str>>> {
+    let mut children = BTreeMap::new();
+    for (name, format) in registry {
+        children.insert(name.as_str(), get_dependencies(format)?);
+    }
+    Ok(children)
+}
+
+/// Classic topological sorting algorithm except that it doesn't abort in case of cycles.
+pub fn best_effort_topological_sort<T>(children: &BTreeMap<T, BTreeSet<T>>) -> Vec<T>
+where
+    T: Clone + std::cmp::Ord + std::cmp::Eq + std::hash::Hash,
+{
+    // Build the initial queue so that we pick up nodes with less children first (and otherwise
+    // those with smaller key first).
+    // This is a heuristic to break cycles preferably at large nodes (see comment below).
+    let mut queue: Vec<_> = children.keys().rev().cloned().collect();
+    queue.sort_by(|node1, node2| children[node1].len().cmp(&children[node2].len()));
+
+    let mut result = Vec::new();
+    // Nodes already inserted in result.
+    let mut sorted = HashSet::new();
+    // Nodes for which children have been enqueued.
+    let mut seen = HashSet::new();
+
+    while let Some(node) = queue.pop() {
+        if sorted.contains(&node) {
+            continue;
+        }
+        if seen.contains(&node) {
+            // Second time we see this node.
+            // * If `node` does not belong to a cycle in the graph, then by now, all its children
+            // have been sorted.
+            // * If `node` has children that depend back on it. We may be visiting `node` again
+            // before some of those children. Just insert `node` here. By ignoring edges going back
+            // to `node` now, we are effectively deciding to "break the cycle" there in future
+            // applications (e.g. `node` may be forward-declared in C++ and `Box`-ed in Rust).
+            sorted.insert(node.clone());
+            result.push(node);
+            continue;
+        }
+        // First time we see this node:
+        // 1. Mark it so that it is no longer enqueued.
+        seen.insert(node.clone());
+        // 2. Schedule all the (yet unseen) children then this node for a second visit.
+        // (If possible, visit children by increasing key.)
+        queue.push(node.clone());
+        for child in children[&node].iter().rev() {
+            if !seen.contains(child) {
+                queue.push(child.clone());
+            }
+        }
+    }
+    result
+}

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -7,7 +7,7 @@
 //! cargo run -p serde-generate -- --help
 //! '''
 
-use serde_generate::python3;
+use serde_generate::{python3, rust};
 use serde_reflection::Registry;
 use std::path::PathBuf;
 use structopt::{clap::arg_enum, StructOpt};
@@ -16,6 +16,7 @@ arg_enum! {
 #[derive(Debug, StructOpt)]
 enum Language {
     Python3,
+    Rust,
 }
 }
 
@@ -42,5 +43,6 @@ fn main() {
 
     match options.language {
         Language::Python3 => python3::output(&mut out, &registry).unwrap(),
+        Language::Rust => rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap(),
     }
 }

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! Supported languages:
 //! * Python 3
+//! * Rust 2018
 
 pub mod analyzer;
 pub mod python3;
+pub mod rust;

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -6,4 +6,5 @@
 //! Supported languages:
 //! * Python 3
 
+pub mod analyzer;
 pub mod python3;

--- a/serde-generate/src/rust.rs
+++ b/serde-generate/src/rust.rs
@@ -1,0 +1,204 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::analyzer;
+use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
+use std::collections::{BTreeMap, HashSet};
+use std::io::{Result, Write};
+
+pub fn output(
+    out: &mut dyn Write,
+    with_derive_macros: bool,
+    registry: &Registry,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    let dependencies = analyzer::get_dependency_map(registry)?;
+    let entries = analyzer::best_effort_topological_sort(&dependencies);
+
+    output_preambule(out, with_derive_macros)?;
+    let mut known_sizes = HashSet::new();
+    for name in entries {
+        let format = &registry[name];
+        output_container(out, with_derive_macros, name, format, &known_sizes)?;
+        known_sizes.insert(name);
+    }
+    Ok(())
+}
+
+fn output_preambule(out: &mut dyn Write, with_derive_macros: bool) -> Result<()> {
+    let serde_imports = if with_derive_macros {
+        r#"
+use serde::{Serialize, Deserialize};
+use serde_bytes::ByteBuf;"#
+    } else {
+        // for testing
+        "type ByteBuf = Vec<u8>;"
+    };
+    writeln!(
+        out,
+        r#"
+#![allow(unused_imports)]{}
+use std::collections::BTreeMap;
+"#,
+        serde_imports
+    )
+}
+
+fn quote_type(format: &Format, known_sizes: Option<&HashSet<&str>>) -> String {
+    use Format::*;
+    match format {
+        TypeName(x) => {
+            if let Some(set) = known_sizes {
+                if !set.contains(x.as_str()) {
+                    return format!("Box<{}>", x);
+                }
+            }
+            x.to_string()
+        }
+        Unit => "()".into(),
+        Bool => "bool".into(),
+        I8 => "i8".into(),
+        I16 => "i16".into(),
+        I32 => "i32".into(),
+        I64 => "i64".into(),
+        I128 => "i128".into(),
+        U8 => "u8".into(),
+        U16 => "u16".into(),
+        U32 => "u32".into(),
+        U64 => "u64".into(),
+        U128 => "u128".into(),
+        F32 => "f32".into(),
+        F64 => "f64".into(),
+        Char => "char".into(),
+        Str => "String".into(),
+        Bytes => "ByteBuf".into(),
+
+        Option(format) => format!("Option<{}>", quote_type(format, known_sizes)),
+        Seq(format) => format!("Vec<{}>", quote_type(format, None)),
+        Map { key, value } => format!(
+            "BTreeMap<{}, {}>",
+            quote_type(key, None),
+            quote_type(value, None)
+        ),
+        Tuple(formats) => format!("({})", quote_types(formats, known_sizes)),
+        TupleArray { content, size } => {
+            format!("[{}; {}]", quote_type(content, known_sizes), *size)
+        }
+
+        Variable(_) => panic!("unexpected value"),
+    }
+}
+
+fn quote_types(formats: &[Format], known_sizes: Option<&HashSet<&str>>) -> String {
+    formats
+        .iter()
+        .map(|x| quote_type(x, known_sizes))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn output_fields(
+    out: &mut dyn Write,
+    indentation: usize,
+    fields: &[Named<Format>],
+    is_pub: bool,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    let mut tab = " ".repeat(indentation);
+    if is_pub {
+        tab += " pub ";
+    }
+    for field in fields {
+        writeln!(
+            out,
+            "{}{}: {},",
+            tab,
+            field.name,
+            quote_type(&field.value, Some(known_sizes)),
+        )?;
+    }
+    Ok(())
+}
+
+fn output_variant(
+    out: &mut dyn Write,
+    name: &str,
+    variant: &VariantFormat,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    use VariantFormat::*;
+    match variant {
+        Unit => writeln!(out, "    {},", name),
+        NewType(format) => writeln!(
+            out,
+            "    {}({}),",
+            name,
+            quote_type(format, Some(known_sizes))
+        ),
+        Tuple(formats) => writeln!(
+            out,
+            "    {}({}),",
+            name,
+            quote_types(formats, Some(known_sizes))
+        ),
+        Struct(fields) => {
+            writeln!(out, "    {} {{", name)?;
+            output_fields(out, 8, fields, false, known_sizes)?;
+            writeln!(out, "    }},")
+        }
+        Variable(_) => panic!("incorrect value"),
+    }
+}
+
+fn output_variants(
+    out: &mut dyn Write,
+    variants: &BTreeMap<u32, Named<VariantFormat>>,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    for (expected_index, (index, variant)) in variants.iter().enumerate() {
+        assert_eq!(*index, expected_index as u32);
+        output_variant(out, &variant.name, &variant.value, known_sizes)?;
+    }
+    Ok(())
+}
+
+fn output_container(
+    out: &mut dyn Write,
+    with_derive_macros: bool,
+    name: &str,
+    format: &ContainerFormat,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    use ContainerFormat::*;
+    let traits = if with_derive_macros {
+        "#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd)]\n"
+    } else {
+        ""
+    };
+    match format {
+        UnitStruct => writeln!(out, "{}pub struct {};\n", traits, name),
+        NewTypeStruct(format) => writeln!(
+            out,
+            "{}pub struct {}({});\n",
+            traits,
+            name,
+            quote_type(format, Some(known_sizes))
+        ),
+        TupleStruct(formats) => writeln!(
+            out,
+            "{}pub struct {}({});\n",
+            traits,
+            name,
+            quote_types(formats, Some(known_sizes))
+        ),
+        Struct(fields) => {
+            writeln!(out, "{}pub struct {} {{", traits, name)?;
+            output_fields(out, 4, fields, true, known_sizes)?;
+            writeln!(out, "}}\n")
+        }
+        Enum(variants) => {
+            writeln!(out, "{}pub enum {} {{", traits, name)?;
+            output_variants(out, variants, known_sizes)?;
+            writeln!(out, "}}\n")
+        }
+    }
+}

--- a/serde-generate/src/rust.rs
+++ b/serde-generate/src/rust.rs
@@ -25,22 +25,10 @@ pub fn output(
 }
 
 fn output_preambule(out: &mut dyn Write, with_derive_macros: bool) -> Result<()> {
-    let serde_imports = if with_derive_macros {
-        r#"
-use serde::{Serialize, Deserialize};
-use serde_bytes::ByteBuf;"#
-    } else {
-        // for testing
-        "type ByteBuf = Vec<u8>;"
-    };
-    writeln!(
-        out,
-        r#"
-#![allow(unused_imports)]{}
-use std::collections::BTreeMap;
-"#,
-        serde_imports
-    )
+    if with_derive_macros {
+        writeln!(out, "use serde::{{Serialize, Deserialize}};\n")?;
+    }
+    Ok(())
 }
 
 fn quote_type(format: &Format, known_sizes: Option<&HashSet<&str>>) -> String {
@@ -70,12 +58,12 @@ fn quote_type(format: &Format, known_sizes: Option<&HashSet<&str>>) -> String {
         F64 => "f64".into(),
         Char => "char".into(),
         Str => "String".into(),
-        Bytes => "ByteBuf".into(),
+        Bytes => "serde_bytes::ByteBuf".into(),
 
         Option(format) => format!("Option<{}>", quote_type(format, known_sizes)),
         Seq(format) => format!("Vec<{}>", quote_type(format, None)),
         Map { key, value } => format!(
-            "BTreeMap<{}, {}>",
+            "std::collections::BTreeMap<{}, {}>",
             quote_type(key, None),
             quote_type(value, None)
         ),

--- a/serde-generate/tests/analyzer.rs
+++ b/serde-generate/tests/analyzer.rs
@@ -1,0 +1,93 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use maplit::{btreemap, btreeset};
+use serde_generate::analyzer;
+
+#[test]
+fn test_topological_sort() {
+    use analyzer::best_effort_topological_sort as tsort;
+    // 2 nodes, no cycle
+    assert_eq!(
+        tsort(&btreemap! {
+            1 => btreeset![2],
+            2 => btreeset![],
+        }),
+        vec![2, 1]
+    );
+    // 3 nodes, no cycle
+    assert_eq!(
+        tsort(&btreemap! {
+            1 => btreeset![2, 3],
+            2 => btreeset![],
+            3 => btreeset![],
+        }),
+        vec![2, 3, 1]
+    );
+    assert_eq!(
+        tsort(&btreemap! {
+            1 => btreeset![2, 3],
+            2 => btreeset![3],
+            3 => btreeset![],
+        }),
+        vec![3, 2, 1]
+    );
+    // Cycles are broken preferably by ignoring edges to nodes with many dependencies.
+    // When 1 is larger.
+    assert_eq!(
+        tsort(&btreemap! {
+            1 => btreeset![2, 4, 5, 3],
+            2 => btreeset![],
+            3 => btreeset![1],
+            4 => btreeset![],
+            5 => btreeset![],
+        }),
+        vec![2, /* ignoring edge to 1 */ 3, 4, 5, 1]
+    );
+    // When 3 is larger
+    assert_eq!(
+        tsort(&btreemap! {
+            1 => btreeset![2, 3],
+            2 => btreeset![],
+            3 => btreeset![1, 4, 5],
+            4 => btreeset![],
+            5 => btreeset![],
+        }),
+        vec![2, /* ignoring edge to 3 */ 1, 4, 5, 3]
+    );
+}
+
+#[test]
+fn test_on_larger_registry() {
+    let registry = test_utils::get_registry().unwrap();
+    let map = analyzer::get_dependency_map(&registry).unwrap();
+    assert_eq!(
+        map.get("SerdeData").unwrap(),
+        &btreeset!(
+            "List",
+            "NewTypeStruct",
+            "OtherTypes",
+            "PrimitiveTypes",
+            "Struct",
+            "Tree",
+            "TupleStruct",
+            "UnitStruct"
+        )
+    );
+
+    let vector = analyzer::best_effort_topological_sort(&map);
+    assert_eq!(
+        vector,
+        vec![
+            "List",
+            "NewTypeStruct",
+            "Struct",
+            "OtherTypes",
+            "PrimitiveTypes",
+            "Tree",
+            "TupleStruct",
+            "UnitStruct",
+            "SerdeData"
+        ]
+    );
+}

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use serde_generate::python3;
+use serde_generate::{python3, rust};
 use std::fs::File;
 use std::process::Command;
 use tempfile::tempdir;
@@ -24,5 +24,63 @@ fn test_that_python_code_parses() {
         .output()
         .unwrap();
     assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}
+
+// Quick test using rustc directly.
+#[test]
+fn test_that_rust_code_compiles() {
+    let registry = test_utils::get_registry().unwrap();
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("test.rs");
+    let mut source = File::create(&source_path).unwrap();
+    rust::output(&mut source, /* with_derive_macros */ false, &registry).unwrap();
+
+    let output = Command::new("rustc")
+        .current_dir(dir.path())
+        .arg("--crate-type")
+        .arg("lib")
+        .arg("--edition")
+        .arg("2018")
+        .arg(source_path)
+        .output()
+        .unwrap();
+    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}
+
+// Full test using cargo. This may take a while.
+#[test]
+fn test_that_rust_code_compiles_with_derive_macros() {
+    let registry = test_utils::get_registry().unwrap();
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[package]
+name = "testing"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
+
+[workspace]
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    let source_path = dir.path().join("src/lib.rs");
+    let mut source = File::create(&source_path).unwrap();
+    rust::output(&mut source, /* with_derive_macros */ true, &registry).unwrap();
+    // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
+    let target_dir = std::env::current_dir().unwrap().join("../target");
+    let output = Command::new("cargo")
+        .current_dir(dir.path())
+        .arg("build")
+        .arg("--target-dir")
+        .arg(target_dir)
+        .output()
+        .unwrap();
     assert!(output.status.success());
 }

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -3,6 +3,7 @@
 
 use serde_generate::{python3, rust};
 use std::fs::File;
+use std::io::Write;
 use std::process::Command;
 use tempfile::tempdir;
 
@@ -34,6 +35,12 @@ fn test_that_rust_code_compiles() {
     let dir = tempdir().unwrap();
     let source_path = dir.path().join("test.rs");
     let mut source = File::create(&source_path).unwrap();
+    // Placeholder for serde_bytes::ByteBuf.
+    writeln!(
+        &mut source,
+        "pub mod serde_bytes {{ pub type ByteBuf = Vec<u8>; }}\n"
+    )
+    .unwrap();
     rust::output(&mut source, /* with_derive_macros */ false, &registry).unwrap();
 
     let output = Command::new("rustc")

--- a/serde-generate/tests/runtime.rs
+++ b/serde-generate/tests/runtime.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use serde_generate::python3;
+use serde_generate::{python3, rust};
 use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
 use std::fs::File;
 use std::io::Write;
@@ -130,5 +130,72 @@ for encoding in encodings:
     std::io::stdout().write(&output.stdout).unwrap();
     std::io::stderr().write(&output.stderr).unwrap();
     assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}
+
+// Full test using cargo. This may take a while.
+#[test]
+fn test_rust_bincode_runtime() {
+    let registry = test_utils::get_registry().unwrap();
+    let dir = tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        r#"[package]
+name = "testing2"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+hex = "0.4.2"
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
+bincode = "1.2"
+
+[workspace]
+"#,
+    )
+    .unwrap();
+    std::fs::create_dir(dir.path().join("src")).unwrap();
+    let source_path = dir.path().join("src/main.rs");
+    let mut source = File::create(&source_path).unwrap();
+    rust::output(&mut source, /* with_derive_macros */ true, &registry).unwrap();
+
+    let values = test_utils::get_sample_values();
+    let hex_encodings: Vec<_> = values
+        .iter()
+        .map(|v| format!("\"{}\"", hex::encode(&bincode::serialize(&v).unwrap())))
+        .collect();
+
+    writeln!(
+        source,
+        r#"
+fn main() {{
+    let hex_encodings = vec![{}];
+
+    for hex_encoding in hex_encodings {{
+        let encoding = hex::decode(hex_encoding).unwrap();
+        let value = bincode::deserialize::<SerdeData>(&encoding).unwrap();
+
+        let s = bincode::serialize(&value).unwrap();
+        assert_eq!(s, encoding);
+    }}
+}}
+"#,
+        hex_encodings.join(", ")
+    )
+    .unwrap();
+
+    // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
+    let target_dir = std::env::current_dir().unwrap().join("../target");
+    let output = Command::new("cargo")
+        .current_dir(dir.path())
+        .arg("run")
+        .arg("--target-dir")
+        .arg(target_dir)
+        .output()
+        .unwrap();
+
+    std::io::stdout().write(&output.stdout).unwrap();
+    std::io::stderr().write(&output.stderr).unwrap();
     assert!(output.status.success());
 }


### PR DESCRIPTION
## Summary

* Generate Rust code from the Serde format. (One possible use case is for documentation)
* End-to-end to verify interoperability using bincode encoding.

## Test Plan

```
cargo test
cargo run -p serde-generate -- --language rust <(curl https://raw.githubusercontent.com/libra/libra/master/testsuite/generate-format/tests/staged/libra.yaml)
```