### PR TITLE
[Serde generate] Code generation, bincode runtime, and LCS runtime for C++

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,11 @@ jobs:
           name: Setup Additional Languages
           command: |
             sudo apt-get update && sudo apt-get upgrade -y
-            sudo apt-get install python3-all-dev python3-pip python3-numpy
+            sudo apt-get install python3-all-dev python3-pip python3-numpy clang llvm
             python3 -m pip install pyre-check
       - run:
           name: Version Information
-          command: rustc --version; cargo --version; rustup --version; python3 --version
+          command: rustc --version; cargo --version; rustup --version; python3 --version; clang++ --version
       - run:
           name: Setup Env
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bincode",
  "hex",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.4.0"
+version = "0.5.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -11,6 +11,7 @@ extracted by [`serde_reflection`](https://crates.io/crates/serde_reflection).
 
 ### Supported Languages
 
+* C++ 17
 * Python 3
 * Rust 2018
 

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -11,8 +11,8 @@ extracted by [`serde_reflection`](https://crates.io/crates/serde_reflection).
 
 ### Supported Languages
 
-* C++ 17
 * Python 3
+* C++ 17
 * Rust 2018
 
 ### Supported Encodings
@@ -36,11 +36,11 @@ cargo run -p serde-generate -- --language python3 test.yaml > test.py
 
 See the help message of the tool with `--help` for more options.
 
-### Bincode Runtime(s)
+### Bincode Runtimes
 
 For testing purposes, we use the Bincode encoding format provided by the
 [`bincode`](https://docs.rs/bincode/1.2.1/bincode/) crate in Rust and
-provide an experimental Bincode runtime in Python.
+provide experimental Bincode runtimes in Python and C++.
 
 In the following example, we transfer a `Test` value from Rust to Python using bincode.
 ```rust

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -33,6 +33,7 @@ class BincodeSerializer {
 
     void serialize_len(size_t value);
     void serialize_variant_index(size_t value);
+    void serialize_option_tag(bool value);
 
     std::vector<uint8_t> bytes() && { return std::move(bytes_); }
 };
@@ -71,6 +72,7 @@ class BincodeDeserializer {
 
     size_t deserialize_len();
     size_t deserialize_variant_index();
+    bool deserialize_option_tag();
 };
 
 void BincodeSerializer::serialize_str(const std::string &value) {
@@ -149,6 +151,10 @@ void BincodeSerializer::serialize_len(size_t value) {
 
 void BincodeSerializer::serialize_variant_index(size_t value) {
     serialize_u32((uint32_t)value);
+}
+
+void BincodeSerializer::serialize_option_tag(bool value) {
+    serialize_bool(value);
 }
 
 std::string BincodeDeserializer::deserialize_str() {
@@ -240,4 +246,8 @@ size_t BincodeDeserializer::deserialize_len() {
 
 size_t BincodeDeserializer::deserialize_variant_index() {
     return (size_t)deserialize_u32();
+}
+
+bool BincodeDeserializer::deserialize_option_tag() {
+    return deserialize_bool();
 }

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -1,0 +1,241 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include "serde.hpp"
+
+class BincodeSerializer {
+    std::vector<uint8_t> bytes_;
+
+  public:
+    BincodeSerializer() {}
+
+    void serialize_str(const std::string &value);
+
+    void serialize_bool(bool value);
+    void serialize_unit();
+    void serialize_char(char32_t value);
+    void serialize_f32(float value);
+    void serialize_f64(double value);
+
+    void serialize_u8(uint8_t value);
+    void serialize_u16(uint16_t value);
+    void serialize_u32(uint32_t value);
+    void serialize_u64(uint64_t value);
+    void serialize_u128(const uint128_t &value);
+
+    void serialize_i8(int8_t value);
+    void serialize_i16(int16_t value);
+    void serialize_i32(int32_t value);
+    void serialize_i64(int64_t value);
+    void serialize_i128(const int128_t &value);
+
+    void serialize_len(size_t value);
+    void serialize_variant_index(size_t value);
+
+    std::vector<uint8_t> bytes() && { return std::move(bytes_); }
+};
+
+class BincodeDeserializer {
+    std::vector<uint8_t> bytes_;
+    size_t pos_;
+
+    uint8_t read_byte();
+
+  public:
+    BincodeDeserializer(std::vector<uint8_t> bytes) {
+        bytes_ = std::move(bytes);
+        pos_ = 0;
+    }
+
+    std::string deserialize_str();
+
+    bool deserialize_bool();
+    void deserialize_unit();
+    char32_t deserialize_char();
+    float deserialize_f32();
+    double deserialize_f64();
+
+    uint8_t deserialize_u8();
+    uint16_t deserialize_u16();
+    uint32_t deserialize_u32();
+    uint64_t deserialize_u64();
+    uint128_t deserialize_u128();
+
+    int8_t deserialize_i8();
+    int16_t deserialize_i16();
+    int32_t deserialize_i32();
+    int64_t deserialize_i64();
+    int128_t deserialize_i128();
+
+    size_t deserialize_len();
+    size_t deserialize_variant_index();
+};
+
+void BincodeSerializer::serialize_str(const std::string &value) {
+    serialize_len(value.size());
+    for (auto c : value) {
+        bytes_.push_back(c);
+    }
+}
+
+void BincodeSerializer::serialize_unit() {}
+
+void BincodeSerializer::serialize_f32(float) { throw "not implemented"; }
+
+void BincodeSerializer::serialize_f64(double) { throw "not implemented"; }
+
+void BincodeSerializer::serialize_char(char32_t) { throw "not implemented"; }
+
+void BincodeSerializer::serialize_bool(bool value) {
+    bytes_.push_back((uint8_t)value);
+}
+
+void BincodeSerializer::serialize_u8(uint8_t value) { bytes_.push_back(value); }
+
+void BincodeSerializer::serialize_u16(uint16_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+}
+
+void BincodeSerializer::serialize_u32(uint32_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+    bytes_.push_back((uint8_t)(value >> 16));
+    bytes_.push_back((uint8_t)(value >> 24));
+}
+
+void BincodeSerializer::serialize_u64(uint64_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+    bytes_.push_back((uint8_t)(value >> 16));
+    bytes_.push_back((uint8_t)(value >> 24));
+    bytes_.push_back((uint8_t)(value >> 32));
+    bytes_.push_back((uint8_t)(value >> 40));
+    bytes_.push_back((uint8_t)(value >> 48));
+    bytes_.push_back((uint8_t)(value >> 56));
+}
+
+void BincodeSerializer::serialize_u128(const uint128_t &value) {
+    serialize_u64(std::get<1>(value));
+    serialize_u64(std::get<0>(value));
+}
+
+void BincodeSerializer::serialize_i8(int8_t value) {
+    serialize_u8((uint8_t)value);
+}
+
+void BincodeSerializer::serialize_i16(int16_t value) {
+    serialize_u16((uint16_t)value);
+}
+
+void BincodeSerializer::serialize_i32(int32_t value) {
+    serialize_u32((uint32_t)value);
+}
+
+void BincodeSerializer::serialize_i64(int64_t value) {
+    serialize_u64((uint64_t)value);
+}
+
+void BincodeSerializer::serialize_i128(const int128_t &value) {
+    serialize_u64(std::get<1>(value));
+    serialize_u64((uint64_t)std::get<0>(value));
+}
+
+void BincodeSerializer::serialize_len(size_t value) {
+    serialize_u64((uint64_t)value);
+}
+
+void BincodeSerializer::serialize_variant_index(size_t value) {
+    serialize_u32((uint32_t)value);
+}
+
+std::string BincodeDeserializer::deserialize_str() {
+    auto len = deserialize_len();
+    std::string result;
+    result.reserve(len);
+    for (size_t i = 0; i < len; i++) {
+        result.push_back(read_byte());
+    }
+    return result;
+}
+
+uint8_t BincodeDeserializer::read_byte() { return bytes_.at(pos_++); }
+
+void BincodeDeserializer::deserialize_unit() {}
+
+float BincodeDeserializer::deserialize_f32() { throw "not implemented"; }
+
+double BincodeDeserializer::deserialize_f64() { throw "not implemented"; }
+
+char32_t BincodeDeserializer::deserialize_char() { throw "not implemented"; }
+
+bool BincodeDeserializer::deserialize_bool() { return (bool)read_byte(); }
+
+uint8_t BincodeDeserializer::deserialize_u8() { return read_byte(); }
+
+uint16_t BincodeDeserializer::deserialize_u16() {
+    uint16_t val = 0;
+    val |= (uint16_t)read_byte();
+    val |= (uint16_t)read_byte() << 8;
+    return val;
+}
+
+uint32_t BincodeDeserializer::deserialize_u32() {
+    uint32_t val = 0;
+    val |= (uint32_t)read_byte();
+    val |= (uint32_t)read_byte() << 8;
+    val |= (uint32_t)read_byte() << 16;
+    val |= (uint32_t)read_byte() << 24;
+    return val;
+}
+
+uint64_t BincodeDeserializer::deserialize_u64() {
+    uint64_t val = 0;
+    val |= (uint64_t)read_byte();
+    val |= (uint64_t)read_byte() << 8;
+    val |= (uint64_t)read_byte() << 16;
+    val |= (uint64_t)read_byte() << 24;
+    val |= (uint64_t)read_byte() << 32;
+    val |= (uint64_t)read_byte() << 40;
+    val |= (uint64_t)read_byte() << 48;
+    val |= (uint64_t)read_byte() << 56;
+    return val;
+}
+
+uint128_t BincodeDeserializer::deserialize_u128() {
+    auto low = deserialize_u64();
+    auto hi = deserialize_u64();
+    return std::tuple{hi, low};
+}
+
+int8_t BincodeDeserializer::deserialize_i8() {
+    return (int8_t)deserialize_u8();
+}
+
+int16_t BincodeDeserializer::deserialize_i16() {
+    return (int16_t)deserialize_u16();
+}
+
+int32_t BincodeDeserializer::deserialize_i32() {
+    return (int32_t)deserialize_u32();
+}
+
+int64_t BincodeDeserializer::deserialize_i64() {
+    return (int64_t)deserialize_u64();
+}
+
+int128_t BincodeDeserializer::deserialize_i128() {
+    auto low = deserialize_u64();
+    auto hi = deserialize_i64();
+    return std::tuple{hi, low};
+}
+
+size_t BincodeDeserializer::deserialize_len() {
+    return (size_t)deserialize_u64();
+}
+
+size_t BincodeDeserializer::deserialize_variant_index() {
+    return (size_t)deserialize_u32();
+}

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -75,40 +75,46 @@ class BincodeDeserializer {
     bool deserialize_option_tag();
 };
 
-void BincodeSerializer::serialize_str(const std::string &value) {
+inline void BincodeSerializer::serialize_str(const std::string &value) {
     serialize_len(value.size());
     for (auto c : value) {
         bytes_.push_back(c);
     }
 }
 
-void BincodeSerializer::serialize_unit() {}
+inline void BincodeSerializer::serialize_unit() {}
 
-void BincodeSerializer::serialize_f32(float) { throw "not implemented"; }
+inline void BincodeSerializer::serialize_f32(float) { throw "not implemented"; }
 
-void BincodeSerializer::serialize_f64(double) { throw "not implemented"; }
+inline void BincodeSerializer::serialize_f64(double) {
+    throw "not implemented";
+}
 
-void BincodeSerializer::serialize_char(char32_t) { throw "not implemented"; }
+inline void BincodeSerializer::serialize_char(char32_t) {
+    throw "not implemented";
+}
 
-void BincodeSerializer::serialize_bool(bool value) {
+inline void BincodeSerializer::serialize_bool(bool value) {
     bytes_.push_back((uint8_t)value);
 }
 
-void BincodeSerializer::serialize_u8(uint8_t value) { bytes_.push_back(value); }
+inline void BincodeSerializer::serialize_u8(uint8_t value) {
+    bytes_.push_back(value);
+}
 
-void BincodeSerializer::serialize_u16(uint16_t value) {
+inline void BincodeSerializer::serialize_u16(uint16_t value) {
     bytes_.push_back((uint8_t)value);
     bytes_.push_back((uint8_t)(value >> 8));
 }
 
-void BincodeSerializer::serialize_u32(uint32_t value) {
+inline void BincodeSerializer::serialize_u32(uint32_t value) {
     bytes_.push_back((uint8_t)value);
     bytes_.push_back((uint8_t)(value >> 8));
     bytes_.push_back((uint8_t)(value >> 16));
     bytes_.push_back((uint8_t)(value >> 24));
 }
 
-void BincodeSerializer::serialize_u64(uint64_t value) {
+inline void BincodeSerializer::serialize_u64(uint64_t value) {
     bytes_.push_back((uint8_t)value);
     bytes_.push_back((uint8_t)(value >> 8));
     bytes_.push_back((uint8_t)(value >> 16));
@@ -119,45 +125,45 @@ void BincodeSerializer::serialize_u64(uint64_t value) {
     bytes_.push_back((uint8_t)(value >> 56));
 }
 
-void BincodeSerializer::serialize_u128(const uint128_t &value) {
+inline void BincodeSerializer::serialize_u128(const uint128_t &value) {
     serialize_u64(value.low);
     serialize_u64(value.high);
 }
 
-void BincodeSerializer::serialize_i8(int8_t value) {
+inline void BincodeSerializer::serialize_i8(int8_t value) {
     serialize_u8((uint8_t)value);
 }
 
-void BincodeSerializer::serialize_i16(int16_t value) {
+inline void BincodeSerializer::serialize_i16(int16_t value) {
     serialize_u16((uint16_t)value);
 }
 
-void BincodeSerializer::serialize_i32(int32_t value) {
+inline void BincodeSerializer::serialize_i32(int32_t value) {
     serialize_u32((uint32_t)value);
 }
 
-void BincodeSerializer::serialize_i64(int64_t value) {
+inline void BincodeSerializer::serialize_i64(int64_t value) {
     serialize_u64((uint64_t)value);
 }
 
-void BincodeSerializer::serialize_i128(const int128_t &value) {
+inline void BincodeSerializer::serialize_i128(const int128_t &value) {
     serialize_u64(value.low);
     serialize_i64(value.high);
 }
 
-void BincodeSerializer::serialize_len(size_t value) {
+inline void BincodeSerializer::serialize_len(size_t value) {
     serialize_u64((uint64_t)value);
 }
 
-void BincodeSerializer::serialize_variant_index(size_t value) {
+inline void BincodeSerializer::serialize_variant_index(size_t value) {
     serialize_u32((uint32_t)value);
 }
 
-void BincodeSerializer::serialize_option_tag(bool value) {
+inline void BincodeSerializer::serialize_option_tag(bool value) {
     serialize_bool(value);
 }
 
-std::string BincodeDeserializer::deserialize_str() {
+inline std::string BincodeDeserializer::deserialize_str() {
     auto len = deserialize_len();
     std::string result;
     result.reserve(len);
@@ -167,28 +173,34 @@ std::string BincodeDeserializer::deserialize_str() {
     return result;
 }
 
-uint8_t BincodeDeserializer::read_byte() { return bytes_.at(pos_++); }
+inline uint8_t BincodeDeserializer::read_byte() { return bytes_.at(pos_++); }
 
-void BincodeDeserializer::deserialize_unit() {}
+inline void BincodeDeserializer::deserialize_unit() {}
 
-float BincodeDeserializer::deserialize_f32() { throw "not implemented"; }
+inline float BincodeDeserializer::deserialize_f32() { throw "not implemented"; }
 
-double BincodeDeserializer::deserialize_f64() { throw "not implemented"; }
+inline double BincodeDeserializer::deserialize_f64() {
+    throw "not implemented";
+}
 
-char32_t BincodeDeserializer::deserialize_char() { throw "not implemented"; }
+inline char32_t BincodeDeserializer::deserialize_char() {
+    throw "not implemented";
+}
 
-bool BincodeDeserializer::deserialize_bool() { return (bool)read_byte(); }
+inline bool BincodeDeserializer::deserialize_bool() {
+    return (bool)read_byte();
+}
 
-uint8_t BincodeDeserializer::deserialize_u8() { return read_byte(); }
+inline uint8_t BincodeDeserializer::deserialize_u8() { return read_byte(); }
 
-uint16_t BincodeDeserializer::deserialize_u16() {
+inline uint16_t BincodeDeserializer::deserialize_u16() {
     uint16_t val = 0;
     val |= (uint16_t)read_byte();
     val |= (uint16_t)read_byte() << 8;
     return val;
 }
 
-uint32_t BincodeDeserializer::deserialize_u32() {
+inline uint32_t BincodeDeserializer::deserialize_u32() {
     uint32_t val = 0;
     val |= (uint32_t)read_byte();
     val |= (uint32_t)read_byte() << 8;
@@ -197,7 +209,7 @@ uint32_t BincodeDeserializer::deserialize_u32() {
     return val;
 }
 
-uint64_t BincodeDeserializer::deserialize_u64() {
+inline uint64_t BincodeDeserializer::deserialize_u64() {
     uint64_t val = 0;
     val |= (uint64_t)read_byte();
     val |= (uint64_t)read_byte() << 8;
@@ -210,44 +222,44 @@ uint64_t BincodeDeserializer::deserialize_u64() {
     return val;
 }
 
-uint128_t BincodeDeserializer::deserialize_u128() {
+inline uint128_t BincodeDeserializer::deserialize_u128() {
     uint128_t result;
     result.low = deserialize_u64();
     result.high = deserialize_u64();
     return result;
 }
 
-int8_t BincodeDeserializer::deserialize_i8() {
+inline int8_t BincodeDeserializer::deserialize_i8() {
     return (int8_t)deserialize_u8();
 }
 
-int16_t BincodeDeserializer::deserialize_i16() {
+inline int16_t BincodeDeserializer::deserialize_i16() {
     return (int16_t)deserialize_u16();
 }
 
-int32_t BincodeDeserializer::deserialize_i32() {
+inline int32_t BincodeDeserializer::deserialize_i32() {
     return (int32_t)deserialize_u32();
 }
 
-int64_t BincodeDeserializer::deserialize_i64() {
+inline int64_t BincodeDeserializer::deserialize_i64() {
     return (int64_t)deserialize_u64();
 }
 
-int128_t BincodeDeserializer::deserialize_i128() {
+inline int128_t BincodeDeserializer::deserialize_i128() {
     int128_t result;
     result.low = deserialize_u64();
     result.high = deserialize_i64();
     return result;
 }
 
-size_t BincodeDeserializer::deserialize_len() {
+inline size_t BincodeDeserializer::deserialize_len() {
     return (size_t)deserialize_u64();
 }
 
-size_t BincodeDeserializer::deserialize_variant_index() {
+inline size_t BincodeDeserializer::deserialize_variant_index() {
     return (size_t)deserialize_u32();
 }
 
-bool BincodeDeserializer::deserialize_option_tag() {
+inline bool BincodeDeserializer::deserialize_option_tag() {
     return deserialize_bool();
 }

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -118,8 +118,8 @@ void BincodeSerializer::serialize_u64(uint64_t value) {
 }
 
 void BincodeSerializer::serialize_u128(const uint128_t &value) {
-    serialize_u64(std::get<1>(value));
-    serialize_u64(std::get<0>(value));
+    serialize_u64(value.low);
+    serialize_u64(value.high);
 }
 
 void BincodeSerializer::serialize_i8(int8_t value) {
@@ -139,8 +139,8 @@ void BincodeSerializer::serialize_i64(int64_t value) {
 }
 
 void BincodeSerializer::serialize_i128(const int128_t &value) {
-    serialize_u64(std::get<1>(value));
-    serialize_u64((uint64_t)std::get<0>(value));
+    serialize_u64(value.low);
+    serialize_i64(value.high);
 }
 
 void BincodeSerializer::serialize_len(size_t value) {
@@ -205,9 +205,10 @@ uint64_t BincodeDeserializer::deserialize_u64() {
 }
 
 uint128_t BincodeDeserializer::deserialize_u128() {
-    auto low = deserialize_u64();
-    auto hi = deserialize_u64();
-    return std::tuple{hi, low};
+    uint128_t result;
+    result.low = deserialize_u64();
+    result.high = deserialize_u64();
+    return result;
 }
 
 int8_t BincodeDeserializer::deserialize_i8() {
@@ -227,9 +228,10 @@ int64_t BincodeDeserializer::deserialize_i64() {
 }
 
 int128_t BincodeDeserializer::deserialize_i128() {
-    auto low = deserialize_u64();
-    auto hi = deserialize_i64();
-    return std::tuple{hi, low};
+    int128_t result;
+    result.low = deserialize_u64();
+    result.high = deserialize_i64();
+    return result;
 }
 
 size_t BincodeDeserializer::deserialize_len() {

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -5,6 +5,8 @@
 
 #include "serde.hpp"
 
+namespace serde {
+
 class BincodeSerializer {
     std::vector<uint8_t> bytes_;
 
@@ -267,3 +269,5 @@ inline size_t BincodeDeserializer::deserialize_variant_index() {
 inline bool BincodeDeserializer::deserialize_option_tag() {
     return deserialize_bool();
 }
+
+} // end of namespace serde

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -35,6 +35,8 @@ class BincodeSerializer {
     void serialize_variant_index(size_t value);
     void serialize_option_tag(bool value);
 
+    static constexpr bool enforce_strict_map_ordering = false;
+
     std::vector<uint8_t> bytes() && { return std::move(bytes_); }
 };
 
@@ -73,6 +75,8 @@ class BincodeDeserializer {
     size_t deserialize_len();
     size_t deserialize_variant_index();
     bool deserialize_option_tag();
+
+    static constexpr bool enforce_strict_map_ordering = false;
 };
 
 inline void BincodeSerializer::serialize_str(const std::string &value) {

--- a/serde-generate/runtime/cpp/lcs.hpp
+++ b/serde-generate/runtime/cpp/lcs.hpp
@@ -7,6 +7,8 @@
 
 #include "serde.hpp"
 
+namespace serde {
+
 // Maximum length supported for LCS sequences and maps.
 constexpr size_t LCS_MAX_LENGTH = 1ull << 31;
 
@@ -344,3 +346,5 @@ inline void LcsDeserializer::check_that_key_slices_are_increasing(
               "expected order";
     }
 }
+
+} // end of namespace serde

--- a/serde-generate/runtime/cpp/lcs.hpp
+++ b/serde-generate/runtime/cpp/lcs.hpp
@@ -1,0 +1,346 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+
+#include "serde.hpp"
+
+// Maximum length supported for LCS sequences and maps.
+constexpr size_t LCS_MAX_LENGTH = 1ull << 31;
+
+class LcsSerializer {
+    std::vector<uint8_t> bytes_;
+
+    void serialize_u32_as_uleb128(uint32_t);
+
+  public:
+    LcsSerializer() {}
+
+    void serialize_str(const std::string &value);
+
+    void serialize_bool(bool value);
+    void serialize_unit();
+    void serialize_char(char32_t value);
+    void serialize_f32(float value);
+    void serialize_f64(double value);
+
+    void serialize_u8(uint8_t value);
+    void serialize_u16(uint16_t value);
+    void serialize_u32(uint32_t value);
+    void serialize_u64(uint64_t value);
+    void serialize_u128(const uint128_t &value);
+
+    void serialize_i8(int8_t value);
+    void serialize_i16(int16_t value);
+    void serialize_i32(int32_t value);
+    void serialize_i64(int64_t value);
+    void serialize_i128(const int128_t &value);
+
+    void serialize_len(size_t value);
+    void serialize_variant_index(size_t value);
+    void serialize_option_tag(bool value);
+
+    static constexpr bool enforce_strict_map_ordering = true;
+    size_t get_buffer_offset();
+    void sort_last_entries(std::vector<size_t> offsets);
+
+    std::vector<uint8_t> bytes() && { return std::move(bytes_); }
+};
+
+class LcsDeserializer {
+    std::vector<uint8_t> bytes_;
+    size_t pos_;
+
+    uint8_t read_byte();
+    uint32_t deserialize_uleb128_as_u32();
+
+  public:
+    LcsDeserializer(std::vector<uint8_t> bytes) {
+        bytes_ = std::move(bytes);
+        pos_ = 0;
+    }
+
+    std::string deserialize_str();
+
+    bool deserialize_bool();
+    void deserialize_unit();
+    char32_t deserialize_char();
+    float deserialize_f32();
+    double deserialize_f64();
+
+    uint8_t deserialize_u8();
+    uint16_t deserialize_u16();
+    uint32_t deserialize_u32();
+    uint64_t deserialize_u64();
+    uint128_t deserialize_u128();
+
+    int8_t deserialize_i8();
+    int16_t deserialize_i16();
+    int32_t deserialize_i32();
+    int64_t deserialize_i64();
+    int128_t deserialize_i128();
+
+    size_t deserialize_len();
+    size_t deserialize_variant_index();
+    bool deserialize_option_tag();
+
+    static constexpr bool enforce_strict_map_ordering = true;
+    size_t get_buffer_offset();
+    void check_that_key_slices_are_increasing(std::tuple<size_t, size_t> key1,
+                                              std::tuple<size_t, size_t> key2);
+};
+
+inline void LcsSerializer::serialize_u32_as_uleb128(uint32_t value) {
+    while (value >= 0x80) {
+        bytes_.push_back((uint8_t)value & 0x7F);
+        value = value >> 7;
+    }
+    bytes_.push_back((uint8_t)value);
+}
+
+inline void LcsSerializer::serialize_str(const std::string &value) {
+    serialize_len(value.size());
+    for (auto c : value) {
+        bytes_.push_back(c);
+    }
+}
+
+inline void LcsSerializer::serialize_unit() {}
+
+inline void LcsSerializer::serialize_f32(float) { throw "not implemented"; }
+
+inline void LcsSerializer::serialize_f64(double) { throw "not implemented"; }
+
+inline void LcsSerializer::serialize_char(char32_t) { throw "not implemented"; }
+
+inline void LcsSerializer::serialize_bool(bool value) {
+    bytes_.push_back((uint8_t)value);
+}
+
+inline void LcsSerializer::serialize_u8(uint8_t value) {
+    bytes_.push_back(value);
+}
+
+inline void LcsSerializer::serialize_u16(uint16_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+}
+
+inline void LcsSerializer::serialize_u32(uint32_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+    bytes_.push_back((uint8_t)(value >> 16));
+    bytes_.push_back((uint8_t)(value >> 24));
+}
+
+inline void LcsSerializer::serialize_u64(uint64_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+    bytes_.push_back((uint8_t)(value >> 16));
+    bytes_.push_back((uint8_t)(value >> 24));
+    bytes_.push_back((uint8_t)(value >> 32));
+    bytes_.push_back((uint8_t)(value >> 40));
+    bytes_.push_back((uint8_t)(value >> 48));
+    bytes_.push_back((uint8_t)(value >> 56));
+}
+
+inline void LcsSerializer::serialize_u128(const uint128_t &value) {
+    serialize_u64(value.low);
+    serialize_u64(value.high);
+}
+
+inline void LcsSerializer::serialize_i8(int8_t value) {
+    serialize_u8((uint8_t)value);
+}
+
+inline void LcsSerializer::serialize_i16(int16_t value) {
+    serialize_u16((uint16_t)value);
+}
+
+inline void LcsSerializer::serialize_i32(int32_t value) {
+    serialize_u32((uint32_t)value);
+}
+
+inline void LcsSerializer::serialize_i64(int64_t value) {
+    serialize_u64((uint64_t)value);
+}
+
+inline void LcsSerializer::serialize_i128(const int128_t &value) {
+    serialize_u64(value.low);
+    serialize_i64(value.high);
+}
+
+inline void LcsSerializer::serialize_len(size_t value) {
+    if (value > LCS_MAX_LENGTH) {
+        throw "Length is too large";
+    }
+    serialize_u32_as_uleb128((uint32_t)value);
+}
+
+inline void LcsSerializer::serialize_variant_index(size_t value) {
+    serialize_u32_as_uleb128((uint32_t)value);
+}
+
+inline void LcsSerializer::serialize_option_tag(bool value) {
+    serialize_bool(value);
+}
+
+inline size_t LcsSerializer::get_buffer_offset() { return bytes_.size(); }
+
+inline void LcsSerializer::sort_last_entries(std::vector<size_t> offsets) {
+    if (offsets.size() <= 1) {
+        return;
+    }
+    offsets.push_back(bytes_.size());
+
+    std::vector<std::vector<uint8_t>> slices;
+    for (auto i = 1; i < offsets.size(); i++) {
+        auto start = bytes_.cbegin() + offsets[i - 1];
+        auto end = bytes_.cbegin() + offsets[i];
+        slices.emplace_back(start, end);
+    }
+
+    std::sort(slices.begin(), slices.end(), [](auto &s1, auto &s2) {
+        return std::lexicographical_compare(s1.begin(), s1.end(), s2.begin(),
+                                            s2.end());
+    });
+
+    bytes_.resize(offsets[0]);
+    for (auto slice : slices) {
+        bytes_.insert(bytes_.end(), slice.begin(), slice.end());
+    }
+    assert(offsets.back() == bytes_.size());
+}
+
+inline uint8_t LcsDeserializer::read_byte() { return bytes_.at(pos_++); }
+
+inline uint32_t LcsDeserializer::deserialize_uleb128_as_u32() {
+    uint64_t value = 0;
+    for (int shift = 0; shift < 32; shift += 7) {
+        auto byte = read_byte();
+        auto digit = byte & 0x7F;
+        value |= digit << shift;
+        if (value > std::numeric_limits<uint32_t>::max()) {
+            throw "Overflow while parsing uleb128-encoded uint32 value";
+        }
+        if (digit == byte) {
+            if (shift > 0 && digit == 0) {
+                throw "Invalid uleb128 number (unexpected zero digit)";
+            }
+            return (uint32_t)value;
+        }
+    }
+    throw "Overflow while parsing uleb128-encoded uint32 value";
+}
+
+inline std::string LcsDeserializer::deserialize_str() {
+    auto len = deserialize_len();
+    std::string result;
+    result.reserve(len);
+    for (size_t i = 0; i < len; i++) {
+        result.push_back(read_byte());
+    }
+    return result;
+}
+
+inline void LcsDeserializer::deserialize_unit() {}
+
+inline float LcsDeserializer::deserialize_f32() { throw "not implemented"; }
+
+inline double LcsDeserializer::deserialize_f64() { throw "not implemented"; }
+
+inline char32_t LcsDeserializer::deserialize_char() { throw "not implemented"; }
+
+inline bool LcsDeserializer::deserialize_bool() { return (bool)read_byte(); }
+
+inline uint8_t LcsDeserializer::deserialize_u8() { return read_byte(); }
+
+inline uint16_t LcsDeserializer::deserialize_u16() {
+    uint16_t val = 0;
+    val |= (uint16_t)read_byte();
+    val |= (uint16_t)read_byte() << 8;
+    return val;
+}
+
+inline uint32_t LcsDeserializer::deserialize_u32() {
+    uint32_t val = 0;
+    val |= (uint32_t)read_byte();
+    val |= (uint32_t)read_byte() << 8;
+    val |= (uint32_t)read_byte() << 16;
+    val |= (uint32_t)read_byte() << 24;
+    return val;
+}
+
+inline uint64_t LcsDeserializer::deserialize_u64() {
+    uint64_t val = 0;
+    val |= (uint64_t)read_byte();
+    val |= (uint64_t)read_byte() << 8;
+    val |= (uint64_t)read_byte() << 16;
+    val |= (uint64_t)read_byte() << 24;
+    val |= (uint64_t)read_byte() << 32;
+    val |= (uint64_t)read_byte() << 40;
+    val |= (uint64_t)read_byte() << 48;
+    val |= (uint64_t)read_byte() << 56;
+    return val;
+}
+
+inline uint128_t LcsDeserializer::deserialize_u128() {
+    uint128_t result;
+    result.low = deserialize_u64();
+    result.high = deserialize_u64();
+    return result;
+}
+
+inline int8_t LcsDeserializer::deserialize_i8() {
+    return (int8_t)deserialize_u8();
+}
+
+inline int16_t LcsDeserializer::deserialize_i16() {
+    return (int16_t)deserialize_u16();
+}
+
+inline int32_t LcsDeserializer::deserialize_i32() {
+    return (int32_t)deserialize_u32();
+}
+
+inline int64_t LcsDeserializer::deserialize_i64() {
+    return (int64_t)deserialize_u64();
+}
+
+inline int128_t LcsDeserializer::deserialize_i128() {
+    int128_t result;
+    result.low = deserialize_u64();
+    result.high = deserialize_i64();
+    return result;
+}
+
+inline size_t LcsDeserializer::deserialize_len() {
+    auto value = deserialize_uleb128_as_u32();
+    if (value > LCS_MAX_LENGTH) {
+        throw "Length is too large";
+    }
+    return (size_t)value;
+}
+
+inline size_t LcsDeserializer::deserialize_variant_index() {
+    return (size_t)deserialize_uleb128_as_u32();
+}
+
+inline bool LcsDeserializer::deserialize_option_tag() {
+    return deserialize_bool();
+}
+
+inline size_t LcsDeserializer::get_buffer_offset() { return pos_; }
+
+inline void LcsDeserializer::check_that_key_slices_are_increasing(
+    std::tuple<size_t, size_t> key1, std::tuple<size_t, size_t> key2) {
+    if (!std::lexicographical_compare(bytes_.cbegin() + std::get<0>(key1),
+                                      bytes_.cbegin() + std::get<1>(key1),
+                                      bytes_.cbegin() + std::get<0>(key2),
+                                      bytes_.cbegin() + std::get<1>(key2))) {
+        throw "Error while decoding map: keys are not serialized in the "
+              "expected order";
+    }
+}

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -205,10 +205,10 @@ struct Serializable<int128_t> {
 // --- Derivation of Serializable for composite types ---
 
 // Unique pointers (non-nullable)
-template <typename T, typename Deleter>
-struct Serializable<std::unique_ptr<T, Deleter>> {
+template <typename T>
+struct Serializable<std::shared_ptr<T>> {
     template <typename Serializer>
-    static void serialize(const std::unique_ptr<T, Deleter> &value,
+    static void serialize(const std::shared_ptr<T> &value,
                           Serializer &serializer) {
         Serializable<T>::serialize(*value, serializer);
     }
@@ -459,10 +459,10 @@ struct Deserializable<int128_t> {
 
 // Unique pointers
 template <typename T>
-struct Deserializable<std::unique_ptr<T>> {
+struct Deserializable<std::shared_ptr<T>> {
     template <typename Deserializer>
-    static std::unique_ptr<T> deserialize(Deserializer &deserializer) {
-        return std::make_unique<T>(
+    static std::shared_ptr<T> deserialize(Deserializer &deserializer) {
+        return std::make_shared<T>(
             Deserializable<T>::deserialize(deserializer));
     }
 };

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -35,3 +35,508 @@ struct Deserializable {
     static T deserialize(Deserializer &deserializer);
 };
 
+// --- Implementation of Serializable for base types ---
+
+// string
+template <>
+struct Serializable<std::string> {
+    template <typename Serializer>
+    static void serialize(const std::string &value, Serializer &serializer) {
+        serializer.serialize_str(value);
+    }
+};
+
+// unit
+template <>
+struct Serializable<std::monostate> {
+    template <typename Serializer>
+    static void serialize(const std::monostate &_value,
+                          Serializer &serializer) {
+        serializer.serialize_unit();
+    }
+};
+
+// bool
+template <>
+struct Serializable<bool> {
+    template <typename Serializer>
+    static void serialize(const bool &value, Serializer &serializer) {
+        serializer.serialize_bool(value);
+    }
+};
+
+// UTF-8 char
+template <>
+struct Serializable<char32_t> {
+    template <typename Serializer>
+    static void serialize(const char32_t &value, Serializer &serializer) {
+        serializer.serialize_char(value);
+    }
+};
+
+// f32
+template <>
+struct Serializable<float> {
+    template <typename Serializer>
+    static void serialize(const float &value, Serializer &serializer) {
+        serializer.serialize_f32(value);
+    }
+};
+
+// f64
+template <>
+struct Serializable<double> {
+    template <typename Serializer>
+    static void serialize(const double &value, Serializer &serializer) {
+        serializer.serialize_f64(value);
+    }
+};
+
+// u8
+template <>
+struct Serializable<uint8_t> {
+    template <typename Serializer>
+    static void serialize(const uint8_t &value, Serializer &serializer) {
+        serializer.serialize_u8(value);
+    }
+};
+
+// u16
+template <>
+struct Serializable<uint16_t> {
+    template <typename Serializer>
+    static void serialize(const uint16_t &value, Serializer &serializer) {
+        serializer.serialize_u16(value);
+    }
+};
+
+// u32
+template <>
+struct Serializable<uint32_t> {
+    template <typename Serializer>
+    static void serialize(const uint32_t &value, Serializer &serializer) {
+        serializer.serialize_u32(value);
+    }
+};
+
+// u64
+template <>
+struct Serializable<uint64_t> {
+    template <typename Serializer>
+    static void serialize(const uint64_t &value, Serializer &serializer) {
+        serializer.serialize_u64(value);
+    }
+};
+
+// u128
+template <>
+struct Serializable<uint128_t> {
+    template <typename Serializer>
+    static void serialize(const uint128_t &value, Serializer &serializer) {
+        serializer.serialize_u128(value);
+    }
+};
+
+// i8
+template <>
+struct Serializable<int8_t> {
+    template <typename Serializer>
+    static void serialize(const int8_t &value, Serializer &serializer) {
+        serializer.serialize_i8(value);
+    }
+};
+
+// i16
+template <>
+struct Serializable<int16_t> {
+    template <typename Serializer>
+    static void serialize(const int16_t &value, Serializer &serializer) {
+        serializer.serialize_i16(value);
+    }
+};
+
+// i32
+template <>
+struct Serializable<int32_t> {
+    template <typename Serializer>
+    static void serialize(const int32_t &value, Serializer &serializer) {
+        serializer.serialize_i32(value);
+    }
+};
+
+// i64
+template <>
+struct Serializable<int64_t> {
+    template <typename Serializer>
+    static void serialize(const int64_t &value, Serializer &serializer) {
+        serializer.serialize_i64(value);
+    }
+};
+
+// i128
+template <>
+struct Serializable<int128_t> {
+    template <typename Serializer>
+    static void serialize(const int128_t &value, Serializer &serializer) {
+        serializer.serialize_i128(value);
+    }
+};
+
+// --- Derivation of Serializable for composite types ---
+
+// Unique pointers (non-nullable)
+template <typename T, typename Deleter>
+struct Serializable<std::unique_ptr<T, Deleter>> {
+    template <typename Serializer>
+    static void serialize(const std::unique_ptr<T, Deleter> &value,
+                          Serializer &serializer) {
+        Serializable<T>::serialize(*value, serializer);
+    }
+};
+
+// Options
+template <typename T>
+struct Serializable<std::optional<T>> {
+    template <typename Serializer>
+    static void serialize(const std::optional<T> &option,
+                          Serializer &serializer) {
+        if (option.has_value()) {
+            serializer.serialize_u8(1);
+            Serializable<T>::serialize(option.value(), serializer);
+        } else {
+            serializer.serialize_u8(0);
+        }
+    }
+};
+
+// Vectors (sequences)
+template <typename T, typename Allocator>
+struct Serializable<std::vector<T, Allocator>> {
+    template <typename Serializer>
+    static void serialize(const std::vector<T, Allocator> &value,
+                          Serializer &serializer) {
+        serializer.serialize_len(value.size());
+        for (const T &item : value) {
+            Serializable<T>::serialize(item, serializer);
+        }
+    }
+};
+
+// Fixed-size arrays
+template <typename T, std::size_t N>
+struct Serializable<std::array<T, N>> {
+    template <typename Serializer>
+    static void serialize(const std::array<T, N> &value,
+                          Serializer &serializer) {
+        for (const T &item : value) {
+            Serializable<T>::serialize(item, serializer);
+        }
+    }
+};
+
+// Maps
+template <typename K, typename V, typename Allocator>
+struct Serializable<std::map<K, V, Allocator>> {
+    template <typename Serializer>
+    static void serialize(const std::map<K, V, Allocator> &value,
+                          Serializer &serializer) {
+        serializer.serialize_len(value.size());
+        for (const auto &item : value) {
+            Serializable<K>::serialize(item.first, serializer);
+            Serializable<V>::serialize(item.second, serializer);
+        }
+    }
+};
+
+// Tuples
+template <class... Types>
+struct Serializable<std::tuple<Types...>> {
+    template <typename Serializer>
+    static void serialize(const std::tuple<Types...> &value,
+                          Serializer &serializer) {
+        // Visit each of the type components.
+        std::apply(
+            [&serializer](Types const &... args) {
+                (Serializable<Types>::serialize(args, serializer), ...);
+            },
+            value);
+    }
+};
+
+// Enums
+template <class... Types>
+struct Serializable<std::variant<Types...>> {
+    template <typename Serializer>
+    static void serialize(const std::variant<Types...> &value,
+                          Serializer &serializer) {
+        // Write the variant index.
+        serializer.serialize_variant_index(value.index());
+        // Visit the inner type.
+        std::visit(
+            [&serializer](const auto &arg) {
+                using T = typename std::decay<decltype(arg)>::type;
+                Serializable<T>::serialize(arg, serializer);
+            },
+            value);
+    }
+};
+
+// --- Implementation of Deserializable for base types ---
+
+// string
+template <>
+struct Deserializable<std::string> {
+    template <typename Deserializer>
+    static std::string deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_str();
+    }
+};
+
+// unit
+template <>
+struct Deserializable<std::monostate> {
+    template <typename Deserializer>
+    static std::monostate deserialize(Deserializer &deserializer) {
+        deserializer.deserialize_unit();
+        return {};
+    }
+};
+
+// bool
+template <>
+struct Deserializable<bool> {
+    template <typename Deserializer>
+    static bool deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_bool();
+    }
+};
+
+// f32
+template <>
+struct Deserializable<float> {
+    template <typename Deserializer>
+    static float deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_f32();
+    }
+};
+
+// f64
+template <>
+struct Deserializable<double> {
+    template <typename Deserializer>
+    static double deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_f64();
+    }
+};
+
+// UTF-8 char
+template <>
+struct Deserializable<char32_t> {
+    template <typename Deserializer>
+    static char32_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_char();
+    }
+};
+
+// u8
+template <>
+struct Deserializable<uint8_t> {
+    template <typename Deserializer>
+    static uint8_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u8();
+    }
+};
+
+// u16
+template <>
+struct Deserializable<uint16_t> {
+    template <typename Deserializer>
+    static uint16_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u16();
+    }
+};
+
+// u32
+template <>
+struct Deserializable<uint32_t> {
+    template <typename Deserializer>
+    static uint32_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u32();
+    }
+};
+
+// u64
+template <>
+struct Deserializable<uint64_t> {
+    template <typename Deserializer>
+    static uint64_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u64();
+    }
+};
+
+// u128
+template <>
+struct Deserializable<uint128_t> {
+    template <typename Deserializer>
+    static uint128_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_u128();
+    }
+};
+
+// i8
+template <>
+struct Deserializable<int8_t> {
+    template <typename Deserializer>
+    static int8_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i8();
+    }
+};
+
+// i16
+template <>
+struct Deserializable<int16_t> {
+    template <typename Deserializer>
+    static int16_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i16();
+    }
+};
+
+// i32
+template <>
+struct Deserializable<int32_t> {
+    template <typename Deserializer>
+    static int32_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i32();
+    }
+};
+
+// i64
+template <>
+struct Deserializable<int64_t> {
+    template <typename Deserializer>
+    static int64_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i64();
+    }
+};
+
+// i128
+template <>
+struct Deserializable<int128_t> {
+    template <typename Deserializer>
+    static int128_t deserialize(Deserializer &deserializer) {
+        return deserializer.deserialize_i128();
+    }
+};
+
+// --- Derivation of Deserializable for composite types ---
+
+// Unique pointers
+template <typename T>
+struct Deserializable<std::unique_ptr<T>> {
+    template <typename Deserializer>
+    static std::unique_ptr<T> deserialize(Deserializer &deserializer) {
+        return std::make_unique<T>(
+            Deserializable<T>::deserialize(deserializer));
+    }
+};
+
+// Options
+template <typename T>
+struct Deserializable<std::optional<T>> {
+    template <typename Deserializer>
+    static std::optional<T> deserialize(Deserializer &deserializer) {
+        auto tag = deserializer.deserialize_u8();
+        if (tag == 0) {
+            return {};
+        } else {
+            if (tag != 1) {
+                throw "invalid option tag";
+            }
+            return {Deserializable<T>::deserialize(deserializer)};
+        }
+    }
+};
+
+// Vectors
+template <typename T, typename Allocator>
+struct Deserializable<std::vector<T, Allocator>> {
+    template <typename Deserializer>
+    static std::vector<T> deserialize(Deserializer &deserializer) {
+        std::vector<T> result;
+        size_t len = deserializer.deserialize_len();
+        for (size_t i = 0; i < len; i++) {
+            result.push_back(Deserializable<T>::deserialize(deserializer));
+        }
+        return result;
+    }
+};
+
+// Maps
+template <typename K, typename V>
+struct Deserializable<std::map<K, V>> {
+    template <typename Deserializer>
+    static std::map<K, V> deserialize(Deserializer &deserializer) {
+        std::map<K, V> result;
+        size_t len = deserializer.deserialize_len();
+        for (size_t i = 0; i < len; i++) {
+            auto key = Deserializable<K>::deserialize(deserializer);
+            auto value = Deserializable<V>::deserialize(deserializer);
+            result.insert({key, value});
+        }
+        return result;
+    }
+};
+
+// Fixed-size arrays
+template <typename T, std::size_t N>
+struct Deserializable<std::array<T, N>> {
+    template <typename Deserializer>
+    static std::array<T, N> deserialize(Deserializer &deserializer) {
+        std::array<T, N> result;
+        for (T &item : result) {
+            item = Deserializable<T>::deserialize(deserializer);
+        }
+        return result;
+    }
+};
+
+// Tuples
+template <class... Types>
+struct Deserializable<std::tuple<Types...>> {
+    template <typename Deserializer>
+    static std::tuple<Types...> deserialize(Deserializer &deserializer) {
+        // Visit each of the type components.
+        return std::make_tuple(
+            Deserializable<Types>::deserialize(deserializer)...);
+    }
+};
+
+// Enums
+template <class... Types>
+struct Deserializable<std::variant<Types...>> {
+    template <typename Deserializer>
+    static std::variant<Types...> deserialize(Deserializer &deserializer) {
+        // A "case" is analog to a particular branch in switch-case over the
+        // index. Given the variant type `T` known statically, we create a
+        // closure that will deserialize a value `T` and return it as a variant.
+        using Case = std::function<std::variant<Types...>(Deserializer &)>;
+        auto make_case = [](auto tag) -> Case {
+            // Obtain the type `T` encoded in the type of `tag ==
+            // std::common_type<T>{}`.
+            using T = typename decltype(tag)::type;
+            auto f = [](Deserializer &de) {
+                return std::variant<Types...>(
+                    Deserializable<T>::deserialize(de));
+            };
+            return f;
+        };
+
+        // The static array of all the cases for this variant.
+        static const std::array<Case, sizeof...(Types)> cases = {
+            make_case(std::common_type<Types>{})...};
+
+        // Read the variant index and execute the corresponding case.
+        auto index = deserializer.deserialize_variant_index();
+        return cases.at(index)(deserializer);
+    }
+};

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -15,9 +15,29 @@
 #include <variant>
 #include <vector>
 
-// Placeholder types for 128-bit integers.
-using uint128_t = std::tuple<uint64_t, uint64_t>;
-using int128_t = std::tuple<int64_t, uint64_t>;
+// Basic implementation for 128-bit unsigned integers.
+struct uint128_t {
+    uint64_t high;
+    uint64_t low;
+
+    friend bool operator==(const uint128_t &, const uint128_t &);
+};
+
+bool operator==(const uint128_t &lhs, const uint128_t &rhs) {
+    return lhs.high == rhs.high && lhs.low == lhs.low;
+}
+
+// 128-bit signed integers.
+struct int128_t {
+    int64_t high;
+    uint64_t low;
+
+    friend bool operator==(const int128_t &, const int128_t &);
+};
+
+bool operator==(const int128_t &lhs, const int128_t &rhs) {
+    return lhs.high == rhs.high && lhs.low == lhs.low;
+}
 
 // Trait to enable serialization of values of type T.
 // This is similar to the `serde::Serialize` trait in Rust.

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -221,10 +221,10 @@ struct Serializable<std::optional<T>> {
     static void serialize(const std::optional<T> &option,
                           Serializer &serializer) {
         if (option.has_value()) {
-            serializer.serialize_u8(1);
+            serializer.serialize_option_tag(true);
             Serializable<T>::serialize(option.value(), serializer);
         } else {
-            serializer.serialize_u8(0);
+            serializer.serialize_option_tag(false);
         }
     }
 };
@@ -465,13 +465,10 @@ template <typename T>
 struct Deserializable<std::optional<T>> {
     template <typename Deserializer>
     static std::optional<T> deserialize(Deserializer &deserializer) {
-        auto tag = deserializer.deserialize_u8();
-        if (tag == 0) {
+        auto tag = deserializer.deserialize_option_tag();
+        if (!tag) {
             return {};
         } else {
-            if (tag != 1) {
-                throw "invalid option tag";
-            }
             return {Deserializable<T>::deserialize(deserializer)};
         }
     }

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -23,7 +23,7 @@ struct uint128_t {
     friend bool operator==(const uint128_t &, const uint128_t &);
 };
 
-bool operator==(const uint128_t &lhs, const uint128_t &rhs) {
+inline bool operator==(const uint128_t &lhs, const uint128_t &rhs) {
     return lhs.high == rhs.high && lhs.low == lhs.low;
 }
 
@@ -35,7 +35,7 @@ struct int128_t {
     friend bool operator==(const int128_t &, const int128_t &);
 };
 
-bool operator==(const int128_t &lhs, const int128_t &rhs) {
+inline bool operator==(const int128_t &lhs, const int128_t &rhs) {
     return lhs.high == rhs.high && lhs.low == lhs.low;
 }
 

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -15,6 +15,8 @@
 #include <variant>
 #include <vector>
 
+namespace serde {
+
 // Basic implementation for 128-bit unsigned integers.
 struct uint128_t {
     uint64_t high;
@@ -578,3 +580,5 @@ struct Deserializable<std::variant<Types...>> {
         return cases.at(index)(deserializer);
     }
 };
+
+} // end of namespace serde

--- a/serde-generate/runtime/cpp/serde.hpp
+++ b/serde-generate/runtime/cpp/serde.hpp
@@ -1,0 +1,37 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+// Placeholder types for 128-bit integers.
+using uint128_t = std::tuple<uint64_t, uint64_t>;
+using int128_t = std::tuple<int64_t, uint64_t>;
+
+// Trait to enable serialization of values of type T.
+// This is similar to the `serde::Serialize` trait in Rust.
+template <typename T>
+struct Serializable {
+    template <typename Serializer>
+    static void serialize(const T &value, Serializer &serializer);
+};
+
+// Trait to enable deserialization of values of type T.
+// This is similar to the `serde::Deserialize` trait in Rust.
+template <typename T>
+struct Deserializable {
+    template <typename Deserializer>
+    static T deserialize(Deserializer &deserializer);
+};
+

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -1,0 +1,341 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::analyzer;
+use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
+use std::collections::{BTreeMap, HashSet};
+use std::io::{Result, Write};
+
+// TODO:
+// * optional namespace
+// * optionally use `using` for newtype/tuple structs and variants, as well as enums
+
+pub fn output(
+    out: &mut dyn Write,
+    registry: &Registry,
+) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    output_preambule(out)?;
+
+    let dependencies = analyzer::get_dependency_map(registry)?;
+    let entries = analyzer::best_effort_topological_sort(&dependencies);
+    let mut known_names = HashSet::new();
+    let mut known_sizes = HashSet::new();
+    for name in entries {
+        for dependency in &dependencies[name] {
+            if !known_names.contains(dependency) {
+                output_container_forward_definition(out, *dependency)?;
+                known_names.insert(*dependency);
+            }
+        }
+        let format = &registry[name];
+        output_container(out, name, format, &known_sizes)?;
+        known_sizes.insert(name);
+        known_names.insert(name);
+    }
+
+    writeln!(out)?;
+    for (name, format) in registry {
+        output_container_traits(out, name, format)?;
+    }
+    Ok(())
+}
+
+fn output_preambule(out: &mut dyn std::io::Write) -> Result<()> {
+    writeln!(out, "#include \"serde.hpp\"\n")
+}
+
+/// If known_sizes is present, we must try to return a type with a known size as well.
+fn quote_type(format: &Format, known_sizes: Option<&HashSet<&str>>, namespace: &str) -> String {
+    use Format::*;
+    match format {
+        TypeName(x) => {
+            if let Some(set) = known_sizes {
+                if !set.contains(x.as_str()) {
+                    return format!("std::unique_ptr<{}{}>", namespace, x);
+                }
+            }
+            format!("{}{}", namespace, x)
+        }
+        Unit => "std::monostate".into(),
+        Bool => "bool".into(),
+        I8 => "int8_t".into(),
+        I16 => "int16_t".into(),
+        I32 => "int32_t".into(),
+        I64 => "int64_t".into(),
+        I128 => "int128_t".into(),
+        U8 => "uint8_t".into(),
+        U16 => "uint16_t".into(),
+        U32 => "uint32_t".into(),
+        U64 => "uint64_t".into(),
+        U128 => "uint128_t".into(),
+        F32 => "float".into(),
+        F64 => "double".into(),
+        Char => "char32_t".into(),
+        Str => "std::string".into(),
+        Bytes => "std::vector<uint8_t>".into(),
+
+        Option(format) => format!(
+            "std::optional<{}>",
+            quote_type(format, known_sizes, namespace)
+        ),
+        Seq(format) => format!("std::vector<{}>", quote_type(format, None, namespace)),
+        Map { key, value } => format!(
+            "std::map<{}, {}>",
+            quote_type(key, None, namespace),
+            quote_type(value, None, namespace)
+        ),
+        Tuple(formats) => format!(
+            "std::tuple<{}>",
+            quote_types(formats, known_sizes, namespace)
+        ),
+        TupleArray { content, size } => format!(
+            "std::array<{}, {}>",
+            quote_type(content, known_sizes, namespace),
+            *size
+        ),
+
+        Variable(_) => panic!("unexpected value"),
+    }
+}
+
+fn quote_types(formats: &[Format], known_sizes: Option<&HashSet<&str>>, namespace: &str) -> String {
+    formats
+        .iter()
+        .map(|x| quote_type(x, known_sizes, namespace))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn output_fields(
+    out: &mut dyn std::io::Write,
+    indentation: usize,
+    fields: &[Named<Format>],
+    known_sizes: &HashSet<&str>,
+    namespace: &str,
+) -> Result<()> {
+    let tab = " ".repeat(indentation);
+    for field in fields {
+        writeln!(
+            out,
+            "{}{} {};",
+            tab,
+            quote_type(&field.value, Some(known_sizes), namespace),
+            field.name
+        )?;
+    }
+    Ok(())
+}
+
+fn output_variant(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    variant: &VariantFormat,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    use VariantFormat::*;
+    let operator = format!("friend bool operator==(const {}&, const {}&);", name, name);
+    match variant {
+        Unit => writeln!(out, "    struct {} {{\n        {}\n    }};", name, operator),
+        NewType(format) => writeln!(
+            out,
+            "    struct {} {{\n        {} value;\n        {}\n    }};",
+            name,
+            quote_type(format, Some(known_sizes), "::"),
+            operator,
+        ),
+        Tuple(formats) => writeln!(
+            out,
+            "    struct {} {{\n        std::tuple<{}> value;\n        {}\n    }};",
+            name,
+            quote_types(formats, Some(known_sizes), "::"),
+            operator
+        ),
+        Struct(fields) => {
+            writeln!(out, "    struct {} {{", name)?;
+            output_fields(out, 8, fields, known_sizes, "::")?;
+            writeln!(out, "        {}\n    }};", operator)
+        }
+        Variable(_) => panic!("incorrect value"),
+    }
+}
+
+fn output_variants(
+    out: &mut dyn std::io::Write,
+    variants: &BTreeMap<u32, Named<VariantFormat>>,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    for (expected_index, (index, variant)) in variants.iter().enumerate() {
+        assert_eq!(*index, expected_index as u32);
+        output_variant(out, &variant.name, &variant.value, known_sizes)?;
+    }
+    Ok(())
+}
+
+fn output_container_forward_definition(out: &mut dyn std::io::Write, name: &str) -> Result<()> {
+    writeln!(out, "struct {};\n", name)
+}
+
+fn output_container(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    format: &ContainerFormat,
+    known_sizes: &HashSet<&str>,
+) -> Result<()> {
+    use ContainerFormat::*;
+    let operator = format!("friend bool operator==(const {}&, const {}&);", name, name);
+    match format {
+        UnitStruct => writeln!(out, "struct {} {{\n    {}\n}};\n", name, operator),
+        NewTypeStruct(format) => writeln!(
+            out,
+            "struct {} {{\n    {} value;\n    {}\n}};\n",
+            name,
+            quote_type(format, Some(known_sizes), ""),
+            operator,
+        ),
+        TupleStruct(formats) => writeln!(
+            out,
+            "struct {} {{\n    std::tuple<{}> value;\n    {}\n}};\n",
+            name,
+            quote_types(formats, Some(known_sizes), ""),
+            operator,
+        ),
+        Struct(fields) => {
+            writeln!(out, "struct {} {{", name)?;
+            output_fields(out, 4, fields, known_sizes, "")?;
+            writeln!(out, "    {}\n}};\n", operator)
+        }
+        Enum(variants) => {
+            writeln!(out, "struct {} {{", name)?;
+            output_variants(out, variants, known_sizes)?;
+            writeln!(
+                out,
+                "    std::variant<{}> value;\n    {}\n}};\n",
+                variants
+                    .iter()
+                    .map(|(_, v)| v.name.clone())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                operator,
+            )
+        }
+    }
+}
+
+fn output_struct_equality_test(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    fields: &[&str],
+) -> Result<()> {
+    writeln!(
+        out,
+        "bool operator==(const {} &lhs, const {} &rhs) {{",
+        name, name,
+    )?;
+    for field in fields {
+        writeln!(
+            out,
+            "    if (!(lhs.{} == rhs.{})) {{ return false; }}",
+            field, field,
+        )?;
+    }
+    writeln!(out, "    return true;\n}}")
+}
+
+fn output_struct_serializable(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    fields: &[&str],
+) -> Result<()> {
+    writeln!(
+        out,
+        r#"
+template <>
+template <typename Serializer>
+void Serializable<{}>::serialize(const {} &obj, Serializer &serializer) {{"#,
+        name, name,
+    )?;
+    for field in fields {
+        writeln!(
+            out,
+            "    Serializable<decltype(obj.{})>::serialize(obj.{}, serializer);",
+            field, field,
+        )?;
+    }
+    writeln!(out, "}}")
+}
+
+fn output_struct_deserializable(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    fields: &[&str],
+) -> Result<()> {
+    writeln!(
+        out,
+        r#"
+template <>
+template <typename Deserializer>
+{} Deserializable<{}>::deserialize(Deserializer &deserializer) {{
+    {} obj;"#,
+        name, name, name,
+    )?;
+    for field in fields {
+        writeln!(
+            out,
+            "    obj.{} = Deserializable<decltype(obj.{})>::deserialize(deserializer);",
+            field, field,
+        )?;
+    }
+    writeln!(out, "    return obj;\n}}")
+}
+
+fn output_struct_traits(out: &mut dyn std::io::Write, name: &str, fields: &[&str]) -> Result<()> {
+    output_struct_equality_test(out, name, fields)?;
+    output_struct_serializable(out, name, fields)?;
+    output_struct_deserializable(out, name, fields)
+}
+
+fn get_variant_fields(format: &VariantFormat) -> Vec<&str> {
+    use VariantFormat::*;
+    match format {
+        Unit => Vec::new(),
+        NewType(_format) => vec!["value"],
+        Tuple(_formats) => vec!["value"],
+        Struct(fields) => fields
+            .iter()
+            .map(|field| field.name.as_str())
+            .collect::<Vec<_>>(),
+        Variable(_) => panic!("incorrect value"),
+    }
+}
+
+fn output_container_traits(
+    out: &mut dyn std::io::Write,
+    name: &str,
+    format: &ContainerFormat,
+) -> Result<()> {
+    use ContainerFormat::*;
+    match format {
+        UnitStruct => output_struct_traits(out, name, &[]),
+        NewTypeStruct(_format) => output_struct_traits(out, name, &["value"]),
+        TupleStruct(_formats) => output_struct_traits(out, name, &["value"]),
+        Struct(fields) => output_struct_traits(
+            out,
+            name,
+            &fields
+                .iter()
+                .map(|field| field.name.as_str())
+                .collect::<Vec<_>>(),
+        ),
+        Enum(variants) => {
+            output_struct_traits(out, name, &["value"])?;
+            for variant in variants.values() {
+                output_struct_traits(
+                    out,
+                    &format!("{}::{}", name, variant.name),
+                    &get_variant_fields(&variant.value),
+                )?;
+            }
+            Ok(())
+        }
+    }
+}

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -38,7 +38,14 @@ pub fn output(
 }
 
 fn output_preambule(out: &mut dyn std::io::Write) -> Result<()> {
-    writeln!(out, "#include \"serde.hpp\"\n")
+    writeln!(
+        out,
+        r#"
+#pragma once
+
+#include "serde.hpp"
+"#
+    )
 }
 
 /// If known_sizes is present, we must try to return a type with a known size as well.

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -7,10 +7,6 @@ use std::collections::{BTreeMap, HashSet};
 use std::io::{Result, Write};
 use std::path::PathBuf;
 
-// TODO:
-// * optional namespace
-// * optionally use `using` for newtype/tuple structs and variants, as well as enums
-
 pub fn output(
     out: &mut dyn Write,
     registry: &Registry,
@@ -52,7 +48,8 @@ fn quote_type(format: &Format, known_sizes: Option<&HashSet<&str>>, namespace: &
         TypeName(x) => {
             if let Some(set) = known_sizes {
                 if !set.contains(x.as_str()) {
-                    return format!("std::unique_ptr<{}{}>", namespace, x);
+                    // Cannot use unique_ptr because we need a copy constructor (e.g. for vectors).
+                    return format!("std::shared_ptr<{}{}>", namespace, x);
                 }
             }
             format!("{}{}", namespace, x)

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -67,12 +67,12 @@ fn quote_type(format: &Format, known_sizes: Option<&HashSet<&str>>, namespace: &
         I16 => "int16_t".into(),
         I32 => "int32_t".into(),
         I64 => "int64_t".into(),
-        I128 => "int128_t".into(),
+        I128 => "serde::int128_t".into(),
         U8 => "uint8_t".into(),
         U16 => "uint16_t".into(),
         U32 => "uint32_t".into(),
         U64 => "uint64_t".into(),
-        U128 => "uint128_t".into(),
+        U128 => "serde::uint128_t".into(),
         F32 => "float".into(),
         F64 => "double".into(),
         Char => "char32_t".into(),
@@ -256,13 +256,13 @@ fn output_struct_serializable(
         r#"
 template <>
 template <typename Serializer>
-void Serializable<{}>::serialize(const {} &obj, Serializer &serializer) {{"#,
+void serde::Serializable<{}>::serialize(const {} &obj, Serializer &serializer) {{"#,
         name, name,
     )?;
     for field in fields {
         writeln!(
             out,
-            "    Serializable<decltype(obj.{})>::serialize(obj.{}, serializer);",
+            "    serde::Serializable<decltype(obj.{})>::serialize(obj.{}, serializer);",
             field, field,
         )?;
     }
@@ -279,14 +279,14 @@ fn output_struct_deserializable(
         r#"
 template <>
 template <typename Deserializer>
-{} Deserializable<{}>::deserialize(Deserializer &deserializer) {{
+{} serde::Deserializable<{}>::deserialize(Deserializer &deserializer) {{
     {} obj;"#,
         name, name, name,
     )?;
     for field in fields {
         writeln!(
             out,
-            "    obj.{} = Deserializable<decltype(obj.{})>::deserialize(deserializer);",
+            "    obj.{} = serde::Deserializable<decltype(obj.{})>::deserialize(deserializer);",
             field, field,
         )?;
     }

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -102,7 +102,7 @@ fn main() {
                         Box::new(python3::Installer::new(install_dir, serde_package_name_opt))
                     }
                     Language::Rust => Box::new(rust::Installer::new(install_dir)),
-                    Language::Cpp => panic!("not supported"),
+                    Language::Cpp => Box::new(cpp::Installer::new(install_dir)),
                 };
 
             if let Some((registry, name)) = named_registry_opt {

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -7,7 +7,7 @@
 //! cargo run -p serde-generate -- --help
 //! '''
 
-use serde_generate::{python3, rust, SourceInstaller};
+use serde_generate::{cpp, python3, rust, SourceInstaller};
 use serde_reflection::Registry;
 use std::path::PathBuf;
 use structopt::{clap::arg_enum, StructOpt};
@@ -16,6 +16,7 @@ arg_enum! {
 #[derive(Debug, StructOpt)]
 enum Language {
     Python3,
+    Cpp,
     Rust,
 }
 }
@@ -89,6 +90,7 @@ fn main() {
                     Language::Rust => {
                         rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap()
                     }
+                    Language::Cpp => cpp::output(&mut out, &registry).unwrap(),
                 }
             }
         }
@@ -100,6 +102,7 @@ fn main() {
                         Box::new(python3::Installer::new(install_dir, serde_package_name_opt))
                     }
                     Language::Rust => Box::new(rust::Installer::new(install_dir)),
+                    Language::Cpp => panic!("not supported"),
                 };
 
             if let Some((registry, name)) = named_registry_opt {

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -82,7 +82,7 @@ fn main() {
 
     match options.target_source_dir {
         None => {
-            if let Some((registry, _)) = named_registry_opt {
+            if let Some((registry, name)) = named_registry_opt {
                 let stdout = std::io::stdout();
                 let mut out = stdout.lock();
                 match options.language {
@@ -90,7 +90,7 @@ fn main() {
                     Language::Rust => {
                         rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap()
                     }
-                    Language::Cpp => cpp::output(&mut out, &registry).unwrap(),
+                    Language::Cpp => cpp::output(&mut out, &registry, Some(&name)).unwrap(),
                 }
             }
         }

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! ## Supported Languages
 //!
+//! * C++ 17
 //! * Python 3
 //! * Rust 2018
 //!
@@ -100,6 +101,8 @@
 
 /// Dependency analysis and topological sort for Serde formats.
 pub mod analyzer;
+/// Support for code-generation in C++
+pub mod cpp;
 /// Support for code-generation in Python 3
 pub mod python3;
 /// Support for code-generation in Rust

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! ## Supported Languages
 //!
-//! * C++ 17
 //! * Python 3
+//! * C++ 17
 //! * Rust 2018
 //!
 //! ## Supported Encodings
@@ -31,11 +31,11 @@
 //!
 //! See the help message of the tool with `--help` for more options.
 //!
-//! ## Bincode Runtime(s)
+//! ## Bincode Runtimes
 //!
 //! For testing purposes, we use the Bincode encoding format provided by the
 //! [`bincode`](https://docs.rs/bincode/1.2.1/bincode/) crate in Rust and
-//! provide an experimental Bincode runtime in Python.
+//! provide experimental Bincode runtimes in Python and C++.
 //!
 //! In the following example, we transfer a `Test` value from Rust to Python using bincode.
 //! ```

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -201,7 +201,7 @@ impl Installer {
         }
     }
 
-    fn open_module_init_file(&self, name: &str) -> Result<std::fs::File> {
+    fn create_module_init_file(&self, name: &str) -> Result<std::fs::File> {
         let dir_path = self.install_dir.join(name);
         std::fs::create_dir_all(&dir_path)?;
         std::fs::File::create(dir_path.join("__init__.py"))
@@ -226,13 +226,13 @@ impl crate::SourceInstaller for Installer {
         name: &str,
         registry: &Registry,
     ) -> std::result::Result<(), Self::Error> {
-        let mut file = self.open_module_init_file(name)?;
+        let mut file = self.create_module_init_file(name)?;
         output_with_optional_serde_package(&mut file, registry, self.serde_package_name.clone())?;
         Ok(())
     }
 
     fn install_serde_runtime(&self) -> std::result::Result<(), Self::Error> {
-        let mut file = self.open_module_init_file("serde_types")?;
+        let mut file = self.create_module_init_file("serde_types")?;
         write!(
             file,
             "{}",
@@ -242,7 +242,7 @@ impl crate::SourceInstaller for Installer {
     }
 
     fn install_bincode_runtime(&self) -> std::result::Result<(), Self::Error> {
-        let mut file = self.open_module_init_file("bincode")?;
+        let mut file = self.create_module_init_file("bincode")?;
         write!(
             file,
             "{}",
@@ -252,7 +252,7 @@ impl crate::SourceInstaller for Installer {
     }
 
     fn install_lcs_runtime(&self) -> std::result::Result<(), Self::Error> {
-        let mut file = self.open_module_init_file("lcs")?;
+        let mut file = self.create_module_init_file("lcs")?;
         write!(
             file,
             "{}",

--- a/serde-generate/tests/bincode_runtime.rs
+++ b/serde-generate/tests/bincode_runtime.rs
@@ -233,6 +233,8 @@ fn test_cpp_bincode_runtime_on_simple_date() {
 #include "bincode.hpp"
 #include "test.hpp"
 
+using namespace serde;
+
 int main() {{
     std::vector<uint8_t> input = {{{}}};
 
@@ -317,6 +319,8 @@ fn test_cpp_bincode_runtime_on_supported_types() {
 #include <cassert>
 #include "bincode.hpp"
 #include "test.hpp"
+
+using namespace serde;
 
 int main() {{
     std::vector<std::vector<uint8_t>> inputs = {{{}}};

--- a/serde-generate/tests/bincode_runtime.rs
+++ b/serde-generate/tests/bincode_runtime.rs
@@ -333,7 +333,7 @@ int main() {{
     )
     .unwrap();
 
-    let output = Command::new("clang++")
+    let status = Command::new("clang++")
         .arg("--std=c++17")
         .arg("-g")
         .arg("-o")
@@ -341,12 +341,9 @@ int main() {{
         .arg("-I")
         .arg("runtime/cpp")
         .arg(source_path)
-        .output()
+        .status()
         .unwrap();
-    std::io::stdout().write(&output.stdout).unwrap();
-    std::io::stderr().write(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 
     let output = Command::new(dir.path().join("test")).output().unwrap();
     std::io::stdout().write(&output.stdout).unwrap();

--- a/serde-generate/tests/bincode_runtime.rs
+++ b/serde-generate/tests/bincode_runtime.rs
@@ -213,9 +213,9 @@ fn test_rust_documentation_on_simple_data() {
 fn test_cpp_bincode_runtime_on_simple_date() {
     let registry = get_local_registry().unwrap();
     let dir = tempdir().unwrap();
-    let source_path = dir.path().join("test.cpp");
-    let mut source = File::create(&source_path).unwrap();
-    cpp::output(&mut source, &registry).unwrap();
+    let header_path = dir.path().join("test.hpp");
+    let mut header = File::create(&header_path).unwrap();
+    cpp::output(&mut header, &registry).unwrap();
 
     let reference = bincode::serialize(&Test {
         a: vec![4, 6],
@@ -224,11 +224,14 @@ fn test_cpp_bincode_runtime_on_simple_date() {
     })
     .unwrap();
 
+    let source_path = dir.path().join("test.cpp");
+    let mut source = File::create(&source_path).unwrap();
     writeln!(
         source,
         r#"
 #include <cassert>
 #include "bincode.hpp"
+#include "test.hpp"
 
 int main() {{
     std::vector<uint8_t> input = {{{}}};
@@ -285,9 +288,9 @@ int main() {{
 fn test_cpp_bincode_runtime_on_supported_types() {
     let registry = test_utils::get_registry().unwrap();
     let dir = tempdir().unwrap();
-    let source_path = dir.path().join("test.cpp");
-    let mut source = File::create(&source_path).unwrap();
-    cpp::output(&mut source, &registry).unwrap();
+    let header_path = dir.path().join("test.hpp");
+    let mut header = File::create(&header_path).unwrap();
+    cpp::output(&mut header, &registry).unwrap();
 
     let values = test_utils::get_sample_values();
     let encodings = values
@@ -306,11 +309,14 @@ fn test_cpp_bincode_runtime_on_supported_types() {
         .collect::<Vec<_>>()
         .join(", ");
 
+    let source_path = dir.path().join("test.cpp");
+    let mut source = File::create(&source_path).unwrap();
     writeln!(
         source,
         r#"
 #include <cassert>
 #include "bincode.hpp"
+#include "test.hpp"
 
 int main() {{
     std::vector<std::vector<uint8_t>> inputs = {{{}}};

--- a/serde-generate/tests/bincode_runtime.rs
+++ b/serde-generate/tests/bincode_runtime.rs
@@ -215,7 +215,7 @@ fn test_cpp_bincode_runtime_on_simple_date() {
     let dir = tempdir().unwrap();
     let header_path = dir.path().join("test.hpp");
     let mut header = File::create(&header_path).unwrap();
-    cpp::output(&mut header, &registry).unwrap();
+    cpp::output(&mut header, &registry, Some("test")).unwrap();
 
     let reference = bincode::serialize(&Test {
         a: vec![4, 6],
@@ -234,6 +234,8 @@ fn test_cpp_bincode_runtime_on_simple_date() {
 #include "test.hpp"
 
 using namespace serde;
+using test::Choice;
+using test::Test;
 
 int main() {{
     std::vector<uint8_t> input = {{{}}};
@@ -292,7 +294,7 @@ fn test_cpp_bincode_runtime_on_supported_types() {
     let dir = tempdir().unwrap();
     let header_path = dir.path().join("test.hpp");
     let mut header = File::create(&header_path).unwrap();
-    cpp::output(&mut header, &registry).unwrap();
+    cpp::output(&mut header, &registry, None).unwrap();
 
     let values = test_utils::get_sample_values();
     let encodings = values

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -74,9 +74,21 @@ fn test_that_installed_python_code_passes_pyre_check() {
 fn test_that_cpp_code_compiles() {
     let registry = test_utils::get_registry().unwrap();
     let dir = tempdir().unwrap();
+    let header_path = dir.path().join("test.hpp");
+    let mut header = File::create(&header_path).unwrap();
+    cpp::output(&mut header, &registry).unwrap();
+
     let source_path = dir.path().join("test.cpp");
     let mut source = File::create(&source_path).unwrap();
-    cpp::output(&mut source, &registry).unwrap();
+    writeln!(
+        source,
+        r#"
+#include <cassert>
+#include "bincode.hpp"
+#include "test.hpp"
+"#
+    )
+    .unwrap();
 
     let output = Command::new("clang++")
         .arg("--std=c++17")

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -76,7 +76,7 @@ fn test_that_cpp_code_compiles() {
     let dir = tempdir().unwrap();
     let header_path = dir.path().join("test.hpp");
     let mut header = File::create(&header_path).unwrap();
-    cpp::output(&mut header, &registry).unwrap();
+    cpp::output(&mut header, &registry, None).unwrap();
 
     let source_path = dir.path().join("test.cpp");
     let mut source = File::create(&source_path).unwrap();

--- a/serde-generate/tests/installer.rs
+++ b/serde-generate/tests/installer.rs
@@ -156,7 +156,7 @@ fn test_that_installed_cpp_code_compiles() {
         .status()
         .unwrap();
 
-    let output = Command::new("clang++")
+    let status = Command::new("clang++")
         .arg("--std=c++17")
         .arg("-c")
         .arg("-o")
@@ -164,8 +164,7 @@ fn test_that_installed_cpp_code_compiles() {
         .arg("-I")
         .arg(dir.path())
         .arg(dir.path().join("test.hpp"))
-        .output()
+        .status()
         .unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 }

--- a/serde-generate/tests/lcs_runtime.rs
+++ b/serde-generate/tests/lcs_runtime.rs
@@ -204,9 +204,9 @@ fn main() {{
 fn test_cpp_lcs_runtime_on_simple_date() {
     let registry = get_local_registry().unwrap();
     let dir = tempdir().unwrap();
-    let source_path = dir.path().join("test.cpp");
-    let mut source = File::create(&source_path).unwrap();
-    cpp::output(&mut source, &registry).unwrap();
+    let header_path = dir.path().join("test.hpp");
+    let mut header = File::create(&header_path).unwrap();
+    cpp::output(&mut header, &registry).unwrap();
 
     let reference = lcs::to_bytes(&Test {
         a: vec![4, 6],
@@ -215,11 +215,14 @@ fn test_cpp_lcs_runtime_on_simple_date() {
     })
     .unwrap();
 
+    let source_path = dir.path().join("test.cpp");
+    let mut source = File::create(&source_path).unwrap();
     writeln!(
         source,
         r#"
 #include <cassert>
 #include "lcs.hpp"
+#include "test.hpp"
 
 int main() {{
     std::vector<uint8_t> input = {{{}}};
@@ -276,9 +279,9 @@ int main() {{
 fn test_cpp_lcs_runtime_on_supported_types() {
     let registry = test_utils::get_registry().unwrap();
     let dir = tempdir().unwrap();
-    let source_path = dir.path().join("test.cpp");
-    let mut source = File::create(&source_path).unwrap();
-    cpp::output(&mut source, &registry).unwrap();
+    let header_path = dir.path().join("test.hpp");
+    let mut header = File::create(&header_path).unwrap();
+    cpp::output(&mut header, &registry).unwrap();
 
     let values = test_utils::get_sample_values();
     let encodings = values
@@ -297,12 +300,15 @@ fn test_cpp_lcs_runtime_on_supported_types() {
         .collect::<Vec<_>>()
         .join(", ");
 
+    let source_path = dir.path().join("test.cpp");
+    let mut source = File::create(&source_path).unwrap();
     writeln!(
         source,
         r#"
 #include <iostream>
 #include <cassert>
 #include "lcs.hpp"
+#include "test.hpp"
 
 int main() {{
     try {{

--- a/serde-generate/tests/lcs_runtime.rs
+++ b/serde-generate/tests/lcs_runtime.rs
@@ -224,6 +224,8 @@ fn test_cpp_lcs_runtime_on_simple_date() {
 #include "lcs.hpp"
 #include "test.hpp"
 
+using namespace serde;
+
 int main() {{
     std::vector<uint8_t> input = {{{}}};
 
@@ -309,6 +311,8 @@ fn test_cpp_lcs_runtime_on_supported_types() {
 #include <cassert>
 #include "lcs.hpp"
 #include "test.hpp"
+
+using namespace serde;
 
 int main() {{
     try {{

--- a/serde-generate/tests/lcs_runtime.rs
+++ b/serde-generate/tests/lcs_runtime.rs
@@ -341,6 +341,9 @@ int main() {{
         .unwrap();
     assert!(status.success());
 
-    let status = Command::new(dir.path().join("test")).status().unwrap();
-    assert!(status.success());
+    let output = Command::new(dir.path().join("test")).output().unwrap();
+    std::io::stdout().write(&output.stdout).unwrap();
+    std::io::stderr().write(&output.stderr).unwrap();
+    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
 }

--- a/serde-generate/tests/lcs_runtime.rs
+++ b/serde-generate/tests/lcs_runtime.rs
@@ -206,7 +206,7 @@ fn test_cpp_lcs_runtime_on_simple_date() {
     let dir = tempdir().unwrap();
     let header_path = dir.path().join("test.hpp");
     let mut header = File::create(&header_path).unwrap();
-    cpp::output(&mut header, &registry).unwrap();
+    cpp::output(&mut header, &registry, None).unwrap();
 
     let reference = lcs::to_bytes(&Test {
         a: vec![4, 6],
@@ -283,7 +283,7 @@ fn test_cpp_lcs_runtime_on_supported_types() {
     let dir = tempdir().unwrap();
     let header_path = dir.path().join("test.hpp");
     let mut header = File::create(&header_path).unwrap();
-    cpp::output(&mut header, &registry).unwrap();
+    cpp::output(&mut header, &registry, None).unwrap();
 
     let values = test_utils::get_sample_values();
     let encodings = values

--- a/serde-generate/tests/runtime.rs
+++ b/serde-generate/tests/runtime.rs
@@ -227,6 +227,7 @@ fn test_cpp_bincode_runtime_on_simple_date() {
     writeln!(
         source,
         r#"
+#include <cassert>
 #include "bincode.hpp"
 
 int main() {{
@@ -308,6 +309,7 @@ fn test_cpp_bincode_runtime_on_supported_types() {
     writeln!(
         source,
         r#"
+#include <cassert>
 #include "bincode.hpp"
 
 int main() {{

--- a/serde-generate/tests/runtime.rs
+++ b/serde-generate/tests/runtime.rs
@@ -11,8 +11,8 @@ use tempfile::tempdir;
 
 #[derive(Serialize, Deserialize)]
 struct Test {
-    a: Vec<u64>,
-    b: (u32, u32),
+    a: Vec<u32>,
+    b: (i64, u64),
     c: Choice,
 }
 
@@ -219,7 +219,7 @@ fn test_cpp_bincode_runtime_on_simple_date() {
 
     let reference = bincode::serialize(&Test {
         a: vec![4, 6],
-        b: (3, 5),
+        b: (-3, 5),
         c: Choice::C { x: 7 },
     })
     .unwrap();
@@ -235,8 +235,8 @@ int main() {{
     auto deserializer = BincodeDeserializer(input);
     auto test = Deserializable<Test>::deserialize(deserializer);
 
-    auto a = std::vector<uint64_t> {{4, 6}};
-    auto b = std::array<uint32_t, 2> {{3, 5}};
+    auto a = std::vector<uint32_t> {{4, 6}};
+    auto b = std::tuple<int64_t, uint64_t> {{-3, 5}};
     auto c = Choice {{ Choice::C {{ 7 }} }};
     auto test2 = Test {{a, b, c}};
 


### PR DESCRIPTION
## Summary

* Code generation for C++ containers
* bincode runtime tested against the Rust implementation
* LCS runtime tested against the [Rust implementation of the Libra repository](https://github.com/libra/libra/tree/master/common/lcs)
* Code installer (check out `cargo run -p serde-generate -- --help` for options)

To minimize the amount of generated, I chose to use "Traits" and a number of C++17 features (or std library additions). The generated code and the runtimes have no dependencies outside c++ stdlib and can be deployed as headers.

Code sharing between bincode and LCS do not require complex "visiting" APIs similar to serde/Rust. However, maps were a bit tricky because LCS requires a strict ordering of keys.

## Test Plan

```
cargo test
cargo run -p serde-generate -- --language Cpp <(curl https://raw.githubusercontent.com/libra/libra/master/testsuite/generate-format/tests/staged/libra.yaml)
```