### PR TITLE
[serde generate] Add options to install module and runtime(s)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "hex",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -7,7 +7,7 @@
 //! cargo run -p serde-generate -- --help
 //! '''
 
-use serde_generate::{python3, rust};
+use serde_generate::{python3, rust, SourceInstaller};
 use serde_reflection::Registry;
 use std::path::PathBuf;
 use structopt::{clap::arg_enum, StructOpt};
@@ -20,6 +20,14 @@ enum Language {
 }
 }
 
+arg_enum! {
+#[derive(Debug, StructOpt, PartialEq, Eq, PartialOrd, Ord)]
+enum Runtime {
+    Serde,
+    Bincode,
+}
+}
+
 #[derive(Debug, StructOpt)]
 #[structopt(
     name = "Serde code generator",
@@ -27,22 +35,73 @@ enum Language {
 )]
 struct Options {
     #[structopt(parse(from_os_str))]
-    input: PathBuf,
+    input: Option<PathBuf>,
 
     #[structopt(long, possible_values = &Language::variants(), case_insensitive = true, default_value = "Python3")]
     language: Language,
+
+    #[structopt(long)]
+    with_runtimes: Vec<Runtime>,
+
+    #[structopt(long)]
+    name: Option<String>,
+
+    #[structopt(long)]
+    target_source_dir: Option<PathBuf>,
 }
 
 fn main() {
     let options = Options::from_args();
-    let content =
-        std::fs::read_to_string(options.input.as_os_str()).expect("input file must be readable");
-    let registry = serde_yaml::from_str::<Registry>(content.as_str()).unwrap();
+    let named_registry_opt = match &options.input {
+        None => None,
+        Some(input) => {
+            let name = options.name.clone().unwrap_or_else(|| {
+                input
+                    .file_stem()
+                    .expect("failed to deduce module name from input path")
+                    .to_string_lossy()
+                    .into_owned()
+            });
+            let content = std::fs::read_to_string(input).expect("input file must be readable");
+            let registry = serde_yaml::from_str::<Registry>(content.as_str()).unwrap();
+            Some((registry, name))
+        }
+    };
 
-    let mut out = std::io::stdout();
+    match options.target_source_dir {
+        None => {
+            if let Some((registry, _)) = named_registry_opt {
+                let stdout = std::io::stdout();
+                let mut out = stdout.lock();
+                match options.language {
+                    Language::Python3 => python3::output(&mut out, &registry).unwrap(),
+                    Language::Rust => {
+                        rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap()
+                    }
+                }
+            }
+        }
 
-    match options.language {
-        Language::Python3 => python3::output(&mut out, &registry).unwrap(),
-        Language::Rust => rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap(),
+        Some(install_dir) => {
+            let installer: Box<dyn SourceInstaller<Error = Box<dyn std::error::Error>>> =
+                match options.language {
+                    Language::Python3 => Box::new(python3::Installer::new(install_dir)),
+                    Language::Rust => Box::new(rust::Installer::new(install_dir)),
+                };
+
+            if let Some((registry, name)) = named_registry_opt {
+                installer.install_module(&name, &registry).unwrap();
+            }
+
+            let runtimes: std::collections::BTreeSet<_> =
+                options.with_runtimes.into_iter().collect();
+
+            for runtime in runtimes {
+                match runtime {
+                    Runtime::Serde => installer.install_serde_runtime().unwrap(),
+                    Runtime::Bincode => installer.install_bincode_runtime().unwrap(),
+                }
+            }
+        }
     }
 }

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -109,3 +109,21 @@ pub mod rust;
 #[doc(hidden)]
 /// Utility functions to help testing code generators.
 pub mod test_utils;
+
+/// How to copy generated source code and available runtimes for a given language.
+pub trait SourceInstaller {
+    type Error;
+
+    /// Create a module exposing the container types contained in the registry.
+    fn install_module(
+        &self,
+        name: &str,
+        registry: &serde_reflection::Registry,
+    ) -> std::result::Result<(), Self::Error>;
+
+    /// Install the serde runtime.
+    fn install_serde_runtime(&self) -> std::result::Result<(), Self::Error>;
+
+    /// Install the bincode runtime.
+    fn install_bincode_runtime(&self) -> std::result::Result<(), Self::Error>;
+}

--- a/serde-generate/tests/installer.rs
+++ b/serde-generate/tests/installer.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde_generate::test_utils;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn test_that_installed_python_code_parses() {
+    let registry = test_utils::get_registry().unwrap();
+    let dir = tempdir().unwrap();
+    let yaml_path = dir.path().join("test.yaml");
+    std::fs::write(yaml_path.clone(), serde_yaml::to_string(&registry).unwrap()).unwrap();
+
+    Command::new("cargo")
+        .arg("run")
+        .arg("-p")
+        .arg("serde-generate")
+        .arg("--")
+        .arg("--language")
+        .arg("python3")
+        .arg("--target-source-dir")
+        .arg(dir.path())
+        .arg("--name")
+        .arg("test_types")
+        .arg("--with-runtimes")
+        .arg("serde")
+        .arg("bincode")
+        .arg("--")
+        .arg(yaml_path)
+        .status()
+        .unwrap();
+
+    let python_path = format!(
+        "{}:{}",
+        std::env::var("PYTHONPATH").unwrap_or(String::new()),
+        dir.path().to_string_lossy(),
+    );
+    let output = Command::new("python3")
+        .arg("-c")
+        .arg("import serde_types; import bincode; import test_types")
+        .env("PYTHONPATH", python_path)
+        .output()
+        .unwrap();
+    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+}
+
+#[test]
+fn test_that_installed_rust_code_compiles() {
+    let registry = test_utils::get_registry().unwrap();
+    let dir = tempdir().unwrap();
+    let yaml_path = dir.path().join("test.yaml");
+    std::fs::write(yaml_path.clone(), serde_yaml::to_string(&registry).unwrap()).unwrap();
+
+    Command::new("cargo")
+        .arg("run")
+        .arg("-p")
+        .arg("serde-generate")
+        .arg("--")
+        .arg("--language")
+        .arg("rust")
+        .arg("--target-source-dir")
+        .arg(dir.path())
+        .arg(yaml_path)
+        .status()
+        .unwrap();
+
+    // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
+    let target_dir = std::env::current_dir().unwrap().join("../target");
+    let status = Command::new("cargo")
+        .current_dir(dir.path().join("test"))
+        .arg("build")
+        .arg("--target-dir")
+        .arg(target_dir)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
## Summary

* Use `include_str!` to embed serde types and the bincode runtime of python into `serdegen`.
* Add options to control how to install a rust crate or python modules for the generated code and the embedded runtimes.

## Test Plan

new unit tests

```
cargo run -p serde-generate -- --with-runtimes serde bincode --name libra_types --target-source-dir ../testing --language python3 <(curl https://raw.githubusercontent.com/libra/libra/master/testsuite/generate-format/tests/staged/libra.yaml) &&
(cd ../testing && python3 -c 'import libra_types as lt; import bincode; help(lt.Transaction)')
```
