### PR TITLE
[serde generate] Add code generation for Java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,11 +35,11 @@ jobs:
           name: Setup Additional Languages
           command: |
             sudo apt-get update && sudo apt-get upgrade -y
-            sudo apt-get install python3-all-dev python3-pip python3-numpy clang llvm
+            sudo apt-get install python3-all-dev python3-pip python3-numpy clang llvm default-jdk
             python3 -m pip install pyre-check
       - run:
           name: Version Information
-          command: rustc --version; cargo --version; rustup --version; python3 --version; clang++ --version
+          command: rustc --version; cargo --version; rustup --version; python3 --version; clang++ --version; javac -version
       - run:
           name: Setup Env
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +168,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +196,30 @@ name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
+name = "include_dir"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d58bdeb22b1c4691106c084b1063781904c35d0f22eda2a283598968eac61a"
+dependencies = [
+ "glob",
+ "include_dir_impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "include_dir_impl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327869970574819d24d1dca25c891856144d29159ab797fa9dc725c5c3f57215"
+dependencies = [
+ "anyhow",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "indexmap"
@@ -334,6 +370,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +470,7 @@ version = "0.5.3"
 dependencies = [
  "bincode",
  "hex",
+ "include_dir",
  "libra-canonical-serialization",
  "maplit",
  "serde",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 ]
 
 [dependencies]
+include_dir = "0.6"
 maplit = "1.0.2"
 serde = { version = "1.0.112", features = ["derive"] }
 serde_bytes = "0.11.3"

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -13,9 +13,12 @@ into type definitions for other programming languages.
 
 The following target languages are currently supported:
 
-* Python 3
 * C++ 17
+* Python 3
 * Rust 2018
+
+Work in progress:
+* Java 8
 
 ### Supported Encodings
 

--- a/serde-generate/runtime/java/serde/Deserializer.java
+++ b/serde-generate/runtime/java/serde/Deserializer.java
@@ -1,0 +1,38 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Vector;
+import java.util.SortedMap;
+
+public interface Deserializer {
+    String deserialize_str() throws IOException;
+    ByteBuffer deserialize_bytes() throws IOException;
+
+    Boolean deserialize_bool() throws IOException;
+    Void deserialize_unit() throws IOException;
+    Character deserialize_char() throws IOException;
+    Float deserialize_f32() throws IOException;
+    Double deserialize_f64() throws IOException;
+
+    @Unsigned Byte deserialize_u8() throws IOException;
+    @Unsigned Short deserialize_u16() throws IOException;
+    @Unsigned Integer deserialize_u32() throws IOException;
+    @Unsigned Long deserialize_u64() throws IOException;
+    @Unsigned @Int128 BigInteger deserialize_u128() throws IOException;
+
+    Byte deserialize_i8() throws IOException;
+    Short deserialize_i16() throws IOException;
+    Integer deserialize_i32() throws IOException;
+    Long deserialize_i64() throws IOException;
+    @Int128 BigInteger deserialize_i128() throws IOException;
+
+    long deserialize_len() throws IOException;
+    int deserialize_variant_index() throws IOException;
+    boolean deserialize_option_tag() throws IOException;
+}

--- a/serde-generate/runtime/java/serde/FixedLength.java
+++ b/serde-generate/runtime/java/serde/FixedLength.java
@@ -1,0 +1,12 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE_USE})
+public @interface FixedLength {
+    int length();
+}

--- a/serde-generate/runtime/java/serde/Int128.java
+++ b/serde-generate/runtime/java/serde/Int128.java
@@ -1,0 +1,10 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE_USE})
+public @interface Int128 {}

--- a/serde-generate/runtime/java/serde/Serializer.java
+++ b/serde-generate/runtime/java/serde/Serializer.java
@@ -1,0 +1,40 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Vector;
+import java.util.SortedMap;
+
+public interface Serializer {
+    void serialize_str(String value) throws IOException;
+    void serialize_bytes(ByteBuffer value) throws IOException;
+
+    void serialize_bool(Boolean value) throws IOException;
+    void serialize_unit(Void value) throws IOException;
+    void serialize_char(Character value) throws IOException;
+    void serialize_f32(Float value) throws IOException;
+    void serialize_f64(Double value) throws IOException;
+
+    void serialize_u8(@Unsigned Byte value) throws IOException;
+    void serialize_u16(@Unsigned Short value) throws IOException;
+    void serialize_u32(@Unsigned Integer value) throws IOException;
+    void serialize_u64(@Unsigned Long value) throws IOException;
+    void serialize_u128(@Unsigned @Int128 BigInteger value) throws IOException;
+
+    void serialize_i8(Byte value) throws IOException;
+    void serialize_i16(Short value) throws IOException;
+    void serialize_i32(Integer value) throws IOException;
+    void serialize_i64(Long value) throws IOException;
+    void serialize_i128(@Int128 BigInteger value) throws IOException;
+
+    void serialize_len(long value) throws IOException;
+    void serialize_variant_index(int value) throws IOException;
+    void serialize_option_tag(boolean value) throws IOException;
+
+    ByteBuffer bytes();
+}

--- a/serde-generate/runtime/java/serde/Tuple2.java
+++ b/serde-generate/runtime/java/serde/Tuple2.java
@@ -1,0 +1,9 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+public class Tuple2<T0, T1> {
+    public T0 field0;
+    public T1 field1;
+}

--- a/serde-generate/runtime/java/serde/Tuple3.java
+++ b/serde-generate/runtime/java/serde/Tuple3.java
@@ -1,0 +1,10 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+public class Tuple3<T0, T1, T2> {
+    public T0 field0;
+    public T1 field1;
+    public T2 field2;
+}

--- a/serde-generate/runtime/java/serde/Tuple4.java
+++ b/serde-generate/runtime/java/serde/Tuple4.java
@@ -1,0 +1,11 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+public class Tuple4<T0, T1, T2, T3> {
+    public T0 field0;
+    public T1 field1;
+    public T2 field2;
+    public T3 field3;
+}

--- a/serde-generate/runtime/java/serde/Tuple5.java
+++ b/serde-generate/runtime/java/serde/Tuple5.java
@@ -1,0 +1,12 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+public class Tuple5<T0, T1, T2, T3, T4> {
+    public T0 field0;
+    public T1 field1;
+    public T2 field2;
+    public T3 field3;
+    public T4 field4;
+}

--- a/serde-generate/runtime/java/serde/Tuple6.java
+++ b/serde-generate/runtime/java/serde/Tuple6.java
@@ -1,0 +1,13 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+public class Tuple6<T0, T1, T2, T3, T4, T5> {
+    public T0 field0;
+    public T1 field1;
+    public T2 field2;
+    public T3 field3;
+    public T4 field4;
+    public T5 field5;
+}

--- a/serde-generate/runtime/java/serde/Unsigned.java
+++ b/serde-generate/runtime/java/serde/Unsigned.java
@@ -1,0 +1,10 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE_USE})
+public @interface Unsigned {}

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -7,7 +7,7 @@
 //! cargo run -p serde-generate -- --help
 //! '''
 
-use serde_generate::{cpp, python3, rust, SourceInstaller};
+use serde_generate::{cpp, java, python3, rust, SourceInstaller};
 use serde_reflection::Registry;
 use std::path::PathBuf;
 use structopt::{clap::arg_enum, StructOpt};
@@ -18,6 +18,7 @@ enum Language {
     Python3,
     Cpp,
     Rust,
+    Java,
 }
 }
 
@@ -93,6 +94,7 @@ fn main() {
                         rust::output(&mut out, /* with_derive_macros */ true, &registry).unwrap()
                     }
                     Language::Cpp => cpp::output(&mut out, &registry, Some(&name)).unwrap(),
+                    Language::Java => java::output(&mut out, &registry, &name).unwrap(),
                 }
             }
         }
@@ -105,6 +107,7 @@ fn main() {
                     }
                     Language::Rust => Box::new(rust::Installer::new(install_dir)),
                     Language::Cpp => Box::new(cpp::Installer::new(install_dir)),
+                    Language::Java => Box::new(java::Installer::new(install_dir)),
                 };
 
             if let Some((registry, name)) = named_registry_opt {

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -1,0 +1,240 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use include_dir::include_dir;
+use serde_reflection::{ContainerFormat, Format, Named, Registry, VariantFormat};
+use std::collections::BTreeMap;
+use std::io::{Result, Write};
+use std::path::PathBuf;
+
+pub fn output(out: &mut dyn Write, registry: &Registry, class_name: &str) -> Result<()> {
+    output_preambule(out, None)?;
+
+    writeln!(out, "public class {} {{", class_name)?;
+    for (name, format) in registry {
+        output_container(out, name, format, /* nested class */ true)?;
+    }
+    writeln!(out, "}}")
+}
+
+fn output_preambule(out: &mut dyn Write, package_name: Option<&str>) -> Result<()> {
+    if let Some(name) = package_name {
+        writeln!(out, "package {};", name,)?;
+    }
+    writeln!(
+        out,
+        r#"
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.Vector;
+import java.util.SortedMap;
+import serde.FixedLength;
+import serde.Int128;
+import serde.Unsigned;
+import serde.Tuple2;
+import serde.Tuple3;
+import serde.Tuple4;
+import serde.Tuple5;
+import serde.Tuple6;
+"#
+    )
+}
+
+fn quote_type(format: &Format) -> String {
+    use Format::*;
+    match format {
+        TypeName(x) => x.to_string(),
+        Unit => "Void".into(),
+        Bool => "Boolean".into(),
+        I8 => "Byte".into(),
+        I16 => "Short".into(),
+        I32 => "Integer".into(),
+        I64 => "Long".into(),
+        I128 => "@Int128 BigInteger".into(),
+        U8 => "@Unsigned Byte".into(),
+        U16 => "@Unsigned Short".into(),
+        U32 => "@Unsigned Integer".into(),
+        U64 => "@Unsigned Long".into(),
+        U128 => "@Unsigned @Int128 BigInteger".into(),
+        F32 => "Float".into(),
+        F64 => "Double".into(),
+        Char => "Character".into(),
+        Str => "String".into(),
+        Bytes => "ByteBuffer".into(),
+
+        Option(format) => format!("Optional<{}>", quote_type(format)),
+        Seq(format) => format!("Vector<{}>", quote_type(format)),
+        Map { key, value } => format!("SortedMap<{}, {}>", quote_type(key), quote_type(value)),
+        Tuple(formats) => format!("Tuple{}<{}>", formats.len(), quote_types(formats)),
+        TupleArray { content, size } => format!(
+            "@FixedLength(length={}) Vector<{}>",
+            size,
+            quote_type(content)
+        ),
+        Variable(_) => panic!("unexpected value"),
+    }
+}
+
+fn quote_types(formats: &[Format]) -> String {
+    formats
+        .iter()
+        .map(quote_type)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn output_fields(out: &mut dyn Write, indentation: usize, fields: &[Named<Format>]) -> Result<()> {
+    let tab = " ".repeat(indentation);
+    for field in fields {
+        writeln!(
+            out,
+            "{} public {} {};",
+            tab,
+            quote_type(&field.value),
+            field.name
+        )?;
+    }
+    Ok(())
+}
+
+fn output_variant(
+    out: &mut dyn Write,
+    base: &str,
+    name: &str,
+    variant: &VariantFormat,
+) -> Result<()> {
+    use VariantFormat::*;
+    let class = format!("    public static class {} extends {}", name, base);
+    match variant {
+        Unit => writeln!(out, "\n{} {{}}", class),
+        NewType(format) => writeln!(
+            out,
+            "\n{} {{\n        public {} value;\n    }}",
+            class,
+            quote_type(format),
+        ),
+        Tuple(formats) => writeln!(
+            out,
+            "\n{} {{\n        public {} value;\n    }}",
+            class,
+            quote_type(&Format::Tuple(formats.clone())),
+        ),
+        Struct(fields) => {
+            writeln!(out, "\n{} {{", class)?;
+            output_fields(out, 8, fields)?;
+            writeln!(out, "    }}")
+        }
+        Variable(_) => panic!("incorrect value"),
+    }
+}
+
+fn output_variants(
+    out: &mut dyn Write,
+    base: &str,
+    variants: &BTreeMap<u32, Named<VariantFormat>>,
+) -> Result<()> {
+    for (_index, variant) in variants {
+        output_variant(out, base, &variant.name, &variant.value)?;
+    }
+    Ok(())
+}
+
+fn output_container(
+    out: &mut dyn Write,
+    name: &str,
+    format: &ContainerFormat,
+    nested_class: bool,
+) -> Result<()> {
+    use ContainerFormat::*;
+    let prefix = if nested_class {
+        "public static "
+    } else {
+        "public "
+    };
+    match format {
+        UnitStruct => writeln!(out, "{}class {} {{}}\n", prefix, name),
+        NewTypeStruct(format) => writeln!(
+            out,
+            "{}class {} {{\n    public {} value;\n}}\n",
+            prefix,
+            name,
+            quote_type(format)
+        ),
+        TupleStruct(formats) => writeln!(
+            out,
+            "{}class {} {{\n    public {} value;\n}}\n",
+            prefix,
+            name,
+            quote_type(&Format::Tuple(formats.clone()))
+        ),
+        Struct(fields) => {
+            writeln!(out, "{}class {} {{", prefix, name)?;
+            output_fields(out, 4, fields)?;
+            writeln!(out, "}}\n")
+        }
+        Enum(variants) => {
+            writeln!(
+                out,
+                r#"{}abstract class {} {{"#,
+                prefix,
+                name
+            )?;
+            output_variants(out, name, variants)?;
+            writeln!(out, "}}")
+        }
+    }
+}
+
+pub struct Installer {
+    install_dir: PathBuf,
+}
+
+impl Installer {
+    pub fn new(install_dir: PathBuf) -> Self {
+        Installer { install_dir }
+    }
+}
+
+impl crate::SourceInstaller for Installer {
+    type Error = Box<dyn std::error::Error>;
+
+    fn install_module(
+        &self,
+        package_name: &str,
+        registry: &Registry,
+    ) -> std::result::Result<(), Self::Error> {
+        let parts = package_name.split('.').collect::<Vec<_>>();
+        let mut dir_path = self.install_dir.clone();
+        for part in &parts {
+            dir_path = dir_path.join(part);
+        }
+        std::fs::create_dir_all(&dir_path)?;
+
+        for (name, format) in registry {
+            let mut file = std::fs::File::create(dir_path.join(name.to_string() + ".java"))?;
+            output_preambule(&mut file, Some(package_name))?;
+            output_container(&mut file, name, format, /* nested class */ false)?;
+        }
+        Ok(())
+    }
+
+    fn install_serde_runtime(&self) -> std::result::Result<(), Self::Error> {
+        let source_dir = include_dir!("runtime/java/serde");
+        let dir_path = self.install_dir.join("serde");
+        std::fs::create_dir_all(&dir_path)?;
+        for entry in source_dir.files() {
+            let mut file = std::fs::File::create(dir_path.join(entry.path()))?;
+            file.write_all(entry.contents())?;
+        }
+        Ok(())
+    }
+
+    fn install_bincode_runtime(&self) -> std::result::Result<(), Self::Error> {
+        panic!("not implemented")
+    }
+
+    fn install_lcs_runtime(&self) -> std::result::Result<(), Self::Error> {
+        panic!("not implemented")
+    }
+}

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -8,9 +8,12 @@
 //!
 //! The following target languages are currently supported:
 //!
-//! * Python 3
 //! * C++ 17
+//! * Python 3
 //! * Rust 2018
+//!
+//! Work in progress:
+//! * Java 8
 //!
 //! ## Supported Encodings
 //!
@@ -111,6 +114,8 @@
 pub mod analyzer;
 /// Support for code-generation in C++
 pub mod cpp;
+/// Support for code-generation in Java
+pub mod java;
 /// Support for code-generation in Python 3
 pub mod python3;
 /// Support for code-generation in Rust

--- a/serde-generate/tests/bincode_runtime.rs
+++ b/serde-generate/tests/bincode_runtime.rs
@@ -70,16 +70,12 @@ assert t != s
     .unwrap();
 
     let python_path = std::env::var("PYTHONPATH").unwrap_or_default() + ":runtime/python";
-    let output = Command::new("python3")
+    let status = Command::new("python3")
         .arg(source_path)
         .env("PYTHONPATH", python_path)
-        .output()
+        .status()
         .unwrap();
-
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 #[test]
@@ -118,16 +114,12 @@ for encoding in encodings:
         "{}:runtime/python",
         std::env::var("PYTHONPATH").unwrap_or_default()
     );
-    let output = Command::new("python3")
+    let status = Command::new("python3")
         .arg(source_path)
         .env("PYTHONPATH", python_path)
-        .output()
+        .status()
         .unwrap();
-
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 // Full test using cargo. This may take a while.
@@ -184,17 +176,14 @@ fn main() {{
 
     // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
     let target_dir = std::env::current_dir().unwrap().join("../target");
-    let output = Command::new("cargo")
+    let status = Command::new("cargo")
         .current_dir(dir.path())
         .arg("run")
         .arg("--target-dir")
         .arg(target_dir)
-        .output()
+        .status()
         .unwrap();
-
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 #[test]
@@ -267,25 +256,19 @@ int main() {{
     )
     .unwrap();
 
-    let output = Command::new("clang++")
+    let status = Command::new("clang++")
         .arg("--std=c++17")
         .arg("-o")
         .arg(dir.path().join("test"))
         .arg("-I")
         .arg("runtime/cpp")
         .arg(source_path)
-        .output()
+        .status()
         .unwrap();
-    std::io::stdout().write(&output.stdout).unwrap();
-    std::io::stderr().write(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 
-    let output = Command::new(dir.path().join("test")).output().unwrap();
-    std::io::stdout().write(&output.stdout).unwrap();
-    std::io::stderr().write(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    let status = Command::new(dir.path().join("test")).status().unwrap();
+    assert!(status.success());
 }
 
 #[test]
@@ -357,9 +340,6 @@ int main() {{
         .unwrap();
     assert!(status.success());
 
-    let output = Command::new(dir.path().join("test")).output().unwrap();
-    std::io::stdout().write(&output.stdout).unwrap();
-    std::io::stderr().write(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    let status = Command::new(dir.path().join("test")).status().unwrap();
+    assert!(status.success());
 }

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -247,7 +247,9 @@ fn test_that_java_code_compiles() {
     let mut source = File::create(&source_path).unwrap();
     java::output(&mut source, &registry, "Test").unwrap();
 
-    let paths = std::fs::read_dir("runtime/java/serde").unwrap().map(|e| e.unwrap().path());
+    let paths = std::fs::read_dir("runtime/java/serde")
+        .unwrap()
+        .map(|e| e.unwrap().path());
     let status = Command::new("javac")
         .arg("-d")
         .arg(dir.path())

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -32,8 +32,7 @@ fn test_that_installed_python_code_passes_pyre_check() {
     let registry = test_utils::get_registry().unwrap();
     let dir = tempdir().unwrap();
 
-    let installer =
-        python3::Installer::new(dir.path().join("src").into(), /* serde package */ None);
+    let installer = python3::Installer::new(dir.path().join("src"), /* serde package */ None);
     installer.install_module("test", &registry).unwrap();
     installer.install_serde_runtime().unwrap();
     installer.install_bincode_runtime().unwrap();

--- a/serde-generate/tests/installer.rs
+++ b/serde-generate/tests/installer.rs
@@ -201,7 +201,9 @@ fn test_that_installed_java_code_compiles() {
         .unwrap();
     assert!(status.success());
 
-    let paths = std::fs::read_dir(dir.path().join("serde")).unwrap().map(|e| e.unwrap().path());
+    let paths = std::fs::read_dir(dir.path().join("serde"))
+        .unwrap()
+        .map(|e| e.unwrap().path());
     let status = Command::new("javac")
         .arg("-cp")
         .arg(dir.path())
@@ -212,7 +214,9 @@ fn test_that_installed_java_code_compiles() {
         .unwrap();
     assert!(status.success());
 
-    let paths = std::fs::read_dir(dir.path().join("test/types")).unwrap().map(|e| e.unwrap().path());
+    let paths = std::fs::read_dir(dir.path().join("test/types"))
+        .unwrap()
+        .map(|e| e.unwrap().path());
     let status = Command::new("javac")
         .arg("-cp")
         .arg(dir.path())

--- a/serde-generate/tests/lcs_runtime.rs
+++ b/serde-generate/tests/lcs_runtime.rs
@@ -71,16 +71,12 @@ assert t != s
     .unwrap();
 
     let python_path = std::env::var("PYTHONPATH").unwrap_or_default() + ":runtime/python";
-    let output = Command::new("python3")
+    let status = Command::new("python3")
         .arg(source_path)
         .env("PYTHONPATH", python_path)
-        .output()
+        .status()
         .unwrap();
-
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 #[test]
@@ -119,16 +115,12 @@ for encoding in encodings:
         "{}:runtime/python",
         std::env::var("PYTHONPATH").unwrap_or_default()
     );
-    let output = Command::new("python3")
+    let status = Command::new("python3")
         .arg(source_path)
         .env("PYTHONPATH", python_path)
-        .output()
+        .status()
         .unwrap();
-
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 // Full test using cargo. This may take a while.
@@ -187,17 +179,14 @@ fn main() {{
 
     // Use a stable `target` dir to avoid downloading and recompiling crates everytime.
     let target_dir = std::env::current_dir().unwrap().join("../target");
-    let output = Command::new("cargo")
+    let status = Command::new("cargo")
         .current_dir(dir.path())
         .arg("run")
         .arg("--target-dir")
         .arg(target_dir)
-        .output()
+        .status()
         .unwrap();
-
-    std::io::stdout().write_all(&output.stdout).unwrap();
-    std::io::stderr().write_all(&output.stderr).unwrap();
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 #[test]
@@ -256,25 +245,19 @@ int main() {{
     )
     .unwrap();
 
-    let output = Command::new("clang++")
+    let status = Command::new("clang++")
         .arg("--std=c++17")
         .arg("-o")
         .arg(dir.path().join("test"))
         .arg("-I")
         .arg("runtime/cpp")
         .arg(source_path)
-        .output()
+        .status()
         .unwrap();
-    std::io::stdout().write(&output.stdout).unwrap();
-    std::io::stderr().write(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 
-    let output = Command::new(dir.path().join("test")).output().unwrap();
-    std::io::stdout().write(&output.stdout).unwrap();
-    std::io::stderr().write(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    let status = Command::new(dir.path().join("test")).status().unwrap();
+    assert!(status.success());
 }
 
 #[test]
@@ -351,9 +334,6 @@ int main() {{
         .unwrap();
     assert!(status.success());
 
-    let output = Command::new(dir.path().join("test")).output().unwrap();
-    std::io::stdout().write(&output.stdout).unwrap();
-    std::io::stderr().write(&output.stderr).unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    let status = Command::new(dir.path().join("test")).status().unwrap();
+    assert!(status.success());
 }


### PR DESCRIPTION
## Summary

Add code generation for Java
* Class definitions
* Serializer and Deserializer interfaces (minimal APIs for now)
* Serialization and Deserialization methods, including name mangling and helper functions for anonymous types.

Serialization runtimes for LCS and bincode (and e2e tests) will be added next.

Notes:
* We are not using any fancy feature such as reflection or template programming so it should be pretty easy to make this approach work for many other languages.
* I used Java type annotations to fill the gaps in Java type system but obviously it is not enforcing anything by itself.

## Test Plan

```
# Quick look (one file) on the generated code for Libra
cargo run -p serde-generate -- --module-name Test --language Java <(curl https://raw.githubusercontent.com/libra/libra/master/testsuite/generate-format/tests/staged/consensus.yaml)

# More realistic setup (many files) + compile
cargo run -p serde-generate -- --module-name libra --target-source-dir test --with-runtimes serde --language Java <(curl https://raw.githubusercontent.com/libra/libra/master/testsuite/generate-format/tests/staged/consensus.yaml)

(cd test && javac serde/*.java libra/*.java)
```