### PR TITLE
[serde generate] Improve java code generation

### DIFF
--- a/serde-generate/runtime/java/serde/ArrayLen.java
+++ b/serde-generate/runtime/java/serde/ArrayLen.java
@@ -7,6 +7,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
 @Target({ElementType.TYPE_USE})
-public @interface FixedLength {
+public @interface ArrayLen {
     int length();
 }

--- a/serde-generate/runtime/java/serde/Deserializer.java
+++ b/serde-generate/runtime/java/serde/Deserializer.java
@@ -12,7 +12,7 @@ import java.util.SortedMap;
 
 public interface Deserializer {
     String deserialize_str() throws IOException;
-    ByteBuffer deserialize_bytes() throws IOException;
+    byte[] deserialize_bytes() throws IOException;
 
     Boolean deserialize_bool() throws IOException;
     Void deserialize_unit() throws IOException;

--- a/serde-generate/runtime/java/serde/Serializer.java
+++ b/serde-generate/runtime/java/serde/Serializer.java
@@ -12,7 +12,7 @@ import java.util.SortedMap;
 
 public interface Serializer {
     void serialize_str(String value) throws IOException;
-    void serialize_bytes(ByteBuffer value) throws IOException;
+    void serialize_bytes(byte[] value) throws IOException;
 
     void serialize_bool(Boolean value) throws IOException;
     void serialize_unit(Void value) throws IOException;

--- a/serde-generate/runtime/java/serde/Tuple2.java
+++ b/serde-generate/runtime/java/serde/Tuple2.java
@@ -6,4 +6,29 @@ package serde;
 public class Tuple2<T0, T1> {
     public T0 field0;
     public T1 field1;
+
+    public Tuple2() {}
+
+    public Tuple2(T0 f0, T1 f1) {
+        this.field0 = f0;
+        this.field1 = f1;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        Tuple2 other = (Tuple2) obj;
+        if (!this.field0.equals(other.field0)) { return false; }
+        if (!this.field1.equals(other.field1)) { return false; }
+        return true;
+    }
+
+    public int hashCode() {
+        int value = 7;
+        value = 31 * value + this.field0.hashCode();
+        value = 31 * value + this.field1.hashCode();
+        return value;
+    }
+
 }

--- a/serde-generate/runtime/java/serde/Tuple3.java
+++ b/serde-generate/runtime/java/serde/Tuple3.java
@@ -7,4 +7,31 @@ public class Tuple3<T0, T1, T2> {
     public T0 field0;
     public T1 field1;
     public T2 field2;
+
+    public Tuple3() {}
+
+    public Tuple3(T0 f0, T1 f1, T2 f2) {
+        this.field0 = f0;
+        this.field1 = f1;
+        this.field2 = f2;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        Tuple3 other = (Tuple3) obj;
+        if (!this.field0.equals(other.field0)) { return false; }
+        if (!this.field1.equals(other.field1)) { return false; }
+        if (!this.field2.equals(other.field2)) { return false; }
+        return true;
+    }
+
+    public int hashCode() {
+        int value = 7;
+        value = 31 * value + this.field0.hashCode();
+        value = 31 * value + this.field1.hashCode();
+        value = 31 * value + this.field2.hashCode();
+        return value;
+    }
 }

--- a/serde-generate/runtime/java/serde/Tuple4.java
+++ b/serde-generate/runtime/java/serde/Tuple4.java
@@ -8,4 +8,35 @@ public class Tuple4<T0, T1, T2, T3> {
     public T1 field1;
     public T2 field2;
     public T3 field3;
+
+    public Tuple4() {}
+
+    public Tuple4(T0 f0, T1 f1, T2 f2, T3 f3) {
+        this.field0 = f0;
+        this.field1 = f1;
+        this.field2 = f2;
+        this.field3 = f3;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        Tuple4 other = (Tuple4) obj;
+        if (!this.field0.equals(other.field0)) { return false; }
+        if (!this.field1.equals(other.field1)) { return false; }
+        if (!this.field2.equals(other.field2)) { return false; }
+        if (!this.field3.equals(other.field3)) { return false; }
+        return true;
+    }
+
+    public int hashCode() {
+        int value = 7;
+        value = 31 * value + this.field0.hashCode();
+        value = 31 * value + this.field1.hashCode();
+        value = 31 * value + this.field2.hashCode();
+        value = 31 * value + this.field3.hashCode();
+        return value;
+    }
+
 }

--- a/serde-generate/runtime/java/serde/Tuple5.java
+++ b/serde-generate/runtime/java/serde/Tuple5.java
@@ -9,4 +9,38 @@ public class Tuple5<T0, T1, T2, T3, T4> {
     public T2 field2;
     public T3 field3;
     public T4 field4;
+
+    public Tuple5() {}
+
+    public Tuple5(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4) {
+        this.field0 = f0;
+        this.field1 = f1;
+        this.field2 = f2;
+        this.field3 = f3;
+        this.field4 = f4;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        Tuple5 other = (Tuple5) obj;
+        if (!this.field0.equals(other.field0)) { return false; }
+        if (!this.field1.equals(other.field1)) { return false; }
+        if (!this.field2.equals(other.field2)) { return false; }
+        if (!this.field3.equals(other.field3)) { return false; }
+        if (!this.field4.equals(other.field4)) { return false; }
+        return true;
+    }
+
+    public int hashCode() {
+        int value = 7;
+        value = 31 * value + this.field0.hashCode();
+        value = 31 * value + this.field1.hashCode();
+        value = 31 * value + this.field2.hashCode();
+        value = 31 * value + this.field3.hashCode();
+        value = 31 * value + this.field4.hashCode();
+        return value;
+    }
+
 }

--- a/serde-generate/runtime/java/serde/Tuple6.java
+++ b/serde-generate/runtime/java/serde/Tuple6.java
@@ -10,4 +10,40 @@ public class Tuple6<T0, T1, T2, T3, T4, T5> {
     public T3 field3;
     public T4 field4;
     public T5 field5;
+
+    public Tuple6() {}
+
+    public Tuple6(T0 f0, T1 f1, T2 f2, T3 f3, T4 f4, T5 f5) {
+        this.field0 = f0;
+        this.field1 = f1;
+        this.field2 = f2;
+        this.field3 = f3;
+        this.field4 = f4;
+        this.field5 = f5;
+    }
+
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null) return false;
+        if (getClass() != obj.getClass()) return false;
+        Tuple6 other = (Tuple6) obj;
+        if (!this.field0.equals(other.field0)) { return false; }
+        if (!this.field1.equals(other.field1)) { return false; }
+        if (!this.field2.equals(other.field2)) { return false; }
+        if (!this.field3.equals(other.field3)) { return false; }
+        if (!this.field4.equals(other.field4)) { return false; }
+        if (!this.field5.equals(other.field5)) { return false; }
+        return true;
+    }
+
+    public int hashCode() {
+        int value = 7;
+        value = 31 * value + this.field0.hashCode();
+        value = 31 * value + this.field1.hashCode();
+        value = 31 * value + this.field2.hashCode();
+        value = 31 * value + this.field3.hashCode();
+        value = 31 * value + this.field4.hashCode();
+        value = 31 * value + this.field5.hashCode();
+        return value;
+    }
 }

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -468,6 +468,7 @@ fn output_variants(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn output_struct_or_variant_container(
     out: &mut dyn Write,
     indentation: usize,

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -88,7 +88,7 @@ fn quote_type(format: &Format, package_prefix: &str) -> String {
             quote_types(formats, package_prefix)
         ),
         TupleArray { content, size } => format!(
-            "{} @ArrayLen({}) []>",
+            "{} @ArrayLen(length={}) []",
             quote_type(content, package_prefix),
             size
         ),
@@ -301,7 +301,7 @@ fn output_serialization_helper(out: &mut dyn Write, name: &str, format0: &Format
             write!(
                 out,
                 r#"
-        assert value.size() == {};
+        assert value.length == {};
         for ({} item : value) {{
             {}
         }}
@@ -407,9 +407,9 @@ fn output_deserialization_helper(out: &mut dyn Write, name: &str, format0: &Form
             write!(
                 out,
                 r#"
-        ArrayList<{}> obj = new ArrayList<{}>({});
-        for (long i = 0; i < {}; i++) {{
-            obj.add({});
+        {}[] obj = new {}[{}];
+        for (int i = 0; i < {}; i++) {{
+            obj[i] = {};
         }}
         return obj;
 "#,

--- a/serde-generate/src/test_utils.rs
+++ b/serde-generate/src/test_utils.rs
@@ -22,6 +22,7 @@ pub enum SerdeData {
     },
     ListWithMutualRecursion(List<Box<SerdeData>>),
     TreeWithMutualRecursion(Tree<Box<SerdeData>>),
+    TupleArray([u32; 3]),
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -201,7 +202,9 @@ pub fn get_sample_values() -> Vec<SerdeData> {
         }],
     });
 
-    vec![v0, v1, v2, v2bis, v3, v4, v5, v6, v7, v8]
+    let v9 = SerdeData::TupleArray([0, 2, 3]);
+
+    vec![v0, v1, v2, v2bis, v3, v4, v5, v6, v7, v8, v9]
 }
 
 #[test]
@@ -298,6 +301,12 @@ SerdeData:
       TreeWithMutualRecursion:
         NEWTYPE:
           TYPENAME: Tree
+    8:
+      TupleArray:
+        NEWTYPE:
+          TUPLEARRAY:
+            CONTENT: U32
+            SIZE: 3
 Struct:
   STRUCT:
     - x: U32


### PR DESCRIPTION
## Summary

Following up with #23 and improving code generation to prepare Libra transaction builders and bincode/LCS runtime implementations.
* Make annotations look more similar to existing Java annotations (e.g. `ArrayLen`)
* Use byte[] for bytes, (Array)List for sequences, (Hash)Map for maps 
* Implement Java traits `equals` and `hashCode`
* Reduce imports and use long names to minimize risks of name collisions
* Better code sharing

## Test Plan

Unit tests