### PR TITLE
[c++] fix bug in LCS serialization of sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "bincode",
  "hex",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.6.0"
+version = "0.6.1"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-generate/runtime/cpp/lcs.hpp
+++ b/serde-generate/runtime/cpp/lcs.hpp
@@ -97,7 +97,7 @@ class LcsDeserializer {
 
 inline void LcsSerializer::serialize_u32_as_uleb128(uint32_t value) {
     while (value >= 0x80) {
-        bytes_.push_back((uint8_t)value & 0x7F);
+        bytes_.push_back((uint8_t)((value & 0x7F) | 0x80));
         value = value >> 7;
     }
     bytes_.push_back((uint8_t)value);

--- a/serde-generate/src/test_utils.rs
+++ b/serde-generate/src/test_utils.rs
@@ -149,6 +149,16 @@ pub fn get_sample_values() -> Vec<SerdeData> {
         f_map: BTreeMap::new(),
     });
 
+    let v2ter = SerdeData::OtherTypes(OtherTypes {
+        f_string: vec!["1"; 1000].join(""),
+        f_bytes: ByteBuf::from(vec![1u8; 300000]),
+        f_option: None,
+        f_unit: (),
+        f_seq: Vec::new(),
+        f_tuple: (4, 5),
+        f_map: BTreeMap::new(),
+    });
+
     let v3 = SerdeData::UnitVariant;
 
     let v4 = SerdeData::NewTypeVariant("test".to_string());
@@ -204,7 +214,7 @@ pub fn get_sample_values() -> Vec<SerdeData> {
 
     let v9 = SerdeData::TupleArray([0, 2, 3]);
 
-    vec![v0, v1, v2, v2bis, v3, v4, v5, v6, v7, v8, v9]
+    vec![v0, v1, v2, v2bis, v2ter, v3, v4, v5, v6, v7, v8, v9]
 }
 
 #[test]


### PR DESCRIPTION
## Summary

A piece of logic was missing in the C++ class for LCS serialization.
This affected serialization (and LCS-based hashing) of strings and sequences of length > 127 (and incidentally enums with this many variants).

## Test Plan

I added a new test case using large strings and large byte-sequences.