### PR TITLE
[Serde generate] add APIs to support comments and external dependencies in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
 ]
@@ -479,6 +479,7 @@ dependencies = [
  "serde_yaml",
  "structopt",
  "tempfile",
+ "textwrap 0.12.1",
 ]
 
 [[package]]
@@ -634,6 +635,15 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "bincode",
  "hex",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.112", features = ["derive"] }
 serde_bytes = "0.11.3"
 serde_yaml = "0.8"
 structopt = "0.3.12"
+textwrap = "0.12.1"
 
 serde-reflection = { path = "../serde-reflection", version = "0.3.0" }
 

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.7.1"
+version = "0.8.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-generate/runtime/java/com/facebook/serde/BinaryDeserializer.java
+++ b/serde-generate/runtime/java/com/facebook/serde/BinaryDeserializer.java
@@ -34,10 +34,10 @@ public abstract class BinaryDeserializer implements Deserializer {
     public Boolean deserialize_bool() throws Exception {
         byte value = input.get();
         if (value == 0) {
-            return new Boolean(false);
+            return Boolean.valueOf(false);
         }
         if (value == 1) {
-            return new Boolean(true);
+            return Boolean.valueOf(true);
         }
         throw new Exception("Incorrect boolean value");
     }

--- a/serde-generate/runtime/python/bincode/__init__.py
+++ b/serde-generate/runtime/python/bincode/__init__.py
@@ -171,6 +171,7 @@ def serialize(obj: typing.Any, obj_type) -> bytes:
             if not dataclasses.is_dataclass(obj_type):
                 raise ValueError("Unexpected type", obj_type)
 
+        # pyre-ignore
         if not isinstance(obj, obj_type):
             raise ValueError("Wrong Value for the type", obj, obj_type)
 

--- a/serde-generate/runtime/python/lcs/__init__.py
+++ b/serde-generate/runtime/python/lcs/__init__.py
@@ -211,6 +211,7 @@ def serialize(obj: typing.Any, obj_type) -> bytes:
             if not dataclasses.is_dataclass(obj_type):
                 raise ValueError("Unexpected type", obj_type)
 
+        # pyre-ignore
         if not isinstance(obj, obj_type):
             raise ValueError("Wrong Value for the type", obj, obj_type)
 

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -123,6 +123,14 @@ pub mod rust;
 /// Utility functions to help testing code generators.
 pub mod test_utils;
 
+/// Track types definitions provided by external modules.
+pub type ExternalDefinitions =
+    std::collections::BTreeMap</* module */ String, /* type names */ Vec<String>>;
+
+/// Track documentation to be attached to particular definitions.
+pub type DocComments =
+    std::collections::BTreeMap</* qualified name */ Vec<String>, /* comment */ String>;
+
 /// How to copy generated source code and available runtimes for a given language.
 pub trait SourceInstaller {
     type Error;

--- a/serde-generate/tests/bincode_runtime.rs
+++ b/serde-generate/tests/bincode_runtime.rs
@@ -380,8 +380,8 @@ public class Main {{
         Testing.Test test = Testing.Test.deserialize(deserializer);
 
         List<@Unsigned Integer> a = Arrays.asList(4, 6);
-        Tuple2<Long, @Unsigned Long> b = new Tuple2<>(new Long(-3), new Long(5));
-        Testing.Choice c = new Testing.Choice.C(new Byte((byte) 7));
+        Tuple2<Long, @Unsigned Long> b = new Tuple2<>(Long.valueOf(-3), Long.valueOf(5));
+        Testing.Choice c = new Testing.Choice.C(Byte.valueOf((byte) 7));
         Testing.Test test2 = new Testing.Test(a, b, c);
 
         assert test.equals(test2);

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -203,9 +203,12 @@ fn test_that_rust_code_with_comments_compiles() {
     let comments = vec![(vec!["SerdeData".to_string()], "Some\ncomments".to_string())]
         .into_iter()
         .collect();
-    let definitions = vec![("foo".to_string(), vec!["Map".to_string(), "Bytes".into()])]
-        .into_iter()
-        .collect();
+    let definitions = vec![
+        ("foo".to_string(), vec!["Map".to_string()]),
+        (String::new(), vec!["Bytes".into()]),
+    ]
+    .into_iter()
+    .collect();
     rust::output_with_external_dependencies_and_comments(
         &mut source,
         /* with_derive_macros */ false,
@@ -231,13 +234,14 @@ fn test_that_rust_code_with_comments_compiles() {
     assert!(!output.status.success());
 
     // Externally defined names "Map" and "Bytes" have caused the usual imports to be
-    // replaced by `use foo::{Map, Bytes}`, so we must add the definitions.
+    // replaced by `use foo::Map` (and nothing, respectively), so we must add the definitions.
     writeln!(
         &mut source,
         r#"
+type Bytes = Vec<u8>;
+
 mod foo {{
     pub type Map<K, V> = std::collections::BTreeMap<K, V>;
-    pub type Bytes = Vec<u8>;
 }}
 "#
     )

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -181,12 +181,6 @@ fn test_that_rust_code_compiles() {
     let source_path = dir.path().join("test.rs");
     let mut source = File::create(&source_path).unwrap();
     rust::output(&mut source, /* with_derive_macros */ false, &registry).unwrap();
-    // Placeholder for serde_bytes::ByteBuf.
-    writeln!(
-        &mut source,
-        "pub mod serde_bytes {{ pub type ByteBuf = Vec<u8>; }}\n"
-    )
-    .unwrap();
 
     let output = Command::new("rustc")
         .current_dir(dir.path())

--- a/serde-generate/tests/lcs_runtime.rs
+++ b/serde-generate/tests/lcs_runtime.rs
@@ -374,8 +374,8 @@ public class Main {{
         Testing.Test test = Testing.Test.deserialize(deserializer);
 
         List<@Unsigned Integer> a = Arrays.asList(4, 6);
-        Tuple2<Long, @Unsigned Long> b = new Tuple2<>(new Long(-3), new Long(5));
-        Testing.Choice c = new Testing.Choice.C(new Byte((byte) 7));
+        Tuple2<Long, @Unsigned Long> b = new Tuple2<>(Long.valueOf(-3), Long.valueOf(5));
+        Testing.Choice c = new Testing.Choice.C(Byte.valueOf((byte) 7));
         Testing.Test test2 = new Testing.Test(a, b, c);
 
         assert test.equals(test2);


### PR DESCRIPTION
## Summary

This is a first attempt in Rust only to support two more use cases:
* Although serde-reflection does not extract comments, we may obtain some by other means: allow injecting them.
* Sometimes we wish to generate classes that refer to definitions from another YAML.

## Test Plan

existing and new unit tests