### PR TITLE
[serde generate] cleanup code-generation

### DIFF
--- a/serde-generate/src/indent.rs
+++ b/serde-generate/src/indent.rs
@@ -41,18 +41,6 @@ impl<T> IndentedWriter<T> {
     }
 }
 
-impl<T> AsRef<T> for IndentedWriter<T> {
-    fn as_ref(&self) -> &T {
-        &self.w
-    }
-}
-
-impl<T> AsMut<T> for IndentedWriter<T> {
-    fn as_mut(&mut self) -> &mut T {
-        &mut self.w
-    }
-}
-
 impl<T: Write> Write for IndentedWriter<T> {
     fn write(&mut self, mut buf: &[u8]) -> Result<usize> {
         let mut bytes_written = 0;

--- a/serde-generate/src/indent.rs
+++ b/serde-generate/src/indent.rs
@@ -24,14 +24,6 @@ impl<T> IndentedWriter<T> {
         }
     }
 
-    pub fn level(&self) -> usize {
-        self.indent_level
-    }
-
-    pub fn set_level(&mut self, level: usize) {
-        self.indent_level = level
-    }
-
     pub fn inc_level(&mut self) {
         self.inc_level_by(1);
     }
@@ -62,7 +54,7 @@ impl<T: Write> Write for IndentedWriter<T> {
                 };
 
             if self.at_begining_of_line && !before_newline.is_empty() {
-                for _ in 0..self.level() {
+                for _ in 0..self.indent_level {
                     match self.indent {
                         IndentConfig::Tab => self.w.write_all(b"\t")?,
                         IndentConfig::Space(n) => {

--- a/serde-generate/src/indent.rs
+++ b/serde-generate/src/indent.rs
@@ -41,6 +41,18 @@ impl<T> IndentedWriter<T> {
     }
 }
 
+impl<T> AsRef<T> for IndentedWriter<T> {
+    fn as_ref(&self) -> &T {
+        &self.w
+    }
+}
+
+impl<T> AsMut<T> for IndentedWriter<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.w
+    }
+}
+
 impl<T: Write> Write for IndentedWriter<T> {
     fn write(&mut self, mut buf: &[u8]) -> Result<usize> {
         let mut bytes_written = 0;

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -11,21 +11,23 @@ use std::{
 };
 
 pub fn output(out: &mut dyn Write, registry: &Registry, class_name: &str) -> Result<()> {
-    output_preambule(out, None)?;
+    let mut emitter = JavaEmitter {
+        out: IndentedWriter::new(out, IndentConfig::Space(4)),
+        package_name: None,
+        nested_class: true,
+        package_prefix: format!("{}.", class_name),
+    };
 
-    writeln!(out, "public final class {} {{\n", class_name)?;
+    emitter.output_preambule()?;
+    writeln!(emitter.out, "public final class {} {{\n", class_name)?;
+    emitter.out.inc_level();
     for (name, format) in registry {
-        output_container(
-            out,
-            name,
-            format,
-            /* nested class */ true,
-            &format!("{}.", class_name),
-        )?;
-        writeln!(out)?;
+        emitter.output_container(name, format)?;
+        writeln!(emitter.out)?;
     }
-    output_trait_helpers(out, registry, /* nested class */ true)?;
-    writeln!(out, "}}")
+    emitter.output_trait_helpers(registry)?;
+    emitter.out.dec_level();
+    writeln!(emitter.out, "}}")
 }
 
 fn write_container_class(
@@ -35,14 +37,15 @@ fn write_container_class(
     format: &ContainerFormat,
 ) -> Result<()> {
     let mut file = std::fs::File::create(install_dir.join(name.to_string() + ".java"))?;
-    output_preambule(&mut file, Some(package_name))?;
-    output_container(
-        &mut file,
-        name,
-        format,
-        /* nested class */ false,
-        &format!("{}.", package_name),
-    )
+    let mut emitter = JavaEmitter {
+        out: IndentedWriter::new(&mut file, IndentConfig::Space(4)),
+        package_name: Some(package_name),
+        nested_class: false,
+        package_prefix: format!("{}.", package_name),
+    };
+
+    emitter.output_preambule()?;
+    emitter.output_container(name, format)
 }
 
 fn write_helper_class(
@@ -51,723 +54,735 @@ fn write_helper_class(
     registry: &Registry,
 ) -> Result<()> {
     let mut file = std::fs::File::create(install_dir.join("TraitHelpers.java"))?;
-    output_preambule(&mut file, Some(package_name))?;
-    output_trait_helpers(&mut file, registry, /* nested class */ false)
+    let mut emitter = JavaEmitter {
+        out: IndentedWriter::new(&mut file, IndentConfig::Space(4)),
+        package_name: Some(package_name),
+        nested_class: false,
+        package_prefix: format!("{}.", package_name),
+    };
+
+    emitter.output_preambule()?;
+    emitter.output_trait_helpers(registry)
 }
 
-fn output_preambule(out: &mut dyn Write, package_name: Option<&str>) -> Result<()> {
-    if let Some(name) = package_name {
-        writeln!(out, "package {};", name)?;
-    }
-    // Java doesn't let us annotate fully-qualified class names.
-    writeln!(
-        out,
-        r#"
+struct JavaEmitter<'a, T> {
+    out: IndentedWriter<T>,
+    package_name: Option<&'a str>,
+    nested_class: bool,
+    package_prefix: String,
+}
+
+impl<'a, T> JavaEmitter<'a, T>
+where
+    T: Write,
+{
+    fn output_preambule(&mut self) -> Result<()> {
+        if let Some(name) = self.package_name {
+            writeln!(self.out, "package {};", name)?;
+        }
+        // Java doesn't let us annotate fully-qualified class names.
+        writeln!(
+            self.out,
+            r#"
 import java.math.BigInteger;
 "#
-    )?;
-    Ok(())
-}
-
-/// A non-empty `package_prefix` is required when the type is quoted from a nested struct.
-fn quote_type(format: &Format, package_prefix: &str) -> String {
-    use Format::*;
-    match format {
-        TypeName(x) => format!("{}{}", package_prefix, x),
-        Unit => "com.facebook.serde.Unit".into(),
-        Bool => "Boolean".into(),
-        I8 => "Byte".into(),
-        I16 => "Short".into(),
-        I32 => "Integer".into(),
-        I64 => "Long".into(),
-        I128 => "@com.facebook.serde.Int128 BigInteger".into(),
-        U8 => "@com.facebook.serde.Unsigned Byte".into(),
-        U16 => "@com.facebook.serde.Unsigned Short".into(),
-        U32 => "@com.facebook.serde.Unsigned Integer".into(),
-        U64 => "@com.facebook.serde.Unsigned Long".into(),
-        U128 => "@com.facebook.serde.Unsigned @com.facebook.serde.Int128 BigInteger".into(),
-        F32 => "Float".into(),
-        F64 => "Double".into(),
-        Char => "Character".into(),
-        Str => "String".into(),
-        Bytes => "com.facebook.serde.Bytes".into(),
-
-        Option(format) => format!("java.util.Optional<{}>", quote_type(format, package_prefix)),
-        Seq(format) => format!("java.util.List<{}>", quote_type(format, package_prefix)),
-        Map { key, value } => format!(
-            "java.util.Map<{}, {}>",
-            quote_type(key, package_prefix),
-            quote_type(value, package_prefix)
-        ),
-        Tuple(formats) => format!(
-            "com.facebook.serde.Tuple{}<{}>",
-            formats.len(),
-            quote_types(formats, package_prefix)
-        ),
-        TupleArray { content, size } => format!(
-            "{} @com.facebook.serde.ArrayLen(length={}) []",
-            quote_type(content, package_prefix),
-            size
-        ),
-        Variable(_) => panic!("unexpected value"),
+        )?;
+        Ok(())
     }
-}
 
-fn quote_types(formats: &[Format], package_prefix: &str) -> String {
-    formats
-        .iter()
-        .map(|f| quote_type(f, package_prefix))
-        .collect::<Vec<_>>()
-        .join(", ")
-}
+    /// A non-empty `package_prefix` is required when the type is quoted from a nested struct.
+    fn quote_type(format: &Format, package_prefix: &str) -> String {
+        use Format::*;
+        match format {
+            TypeName(x) => format!("{}{}", package_prefix, x),
+            Unit => "com.facebook.serde.Unit".into(),
+            Bool => "Boolean".into(),
+            I8 => "Byte".into(),
+            I16 => "Short".into(),
+            I32 => "Integer".into(),
+            I64 => "Long".into(),
+            I128 => "@com.facebook.serde.Int128 BigInteger".into(),
+            U8 => "@com.facebook.serde.Unsigned Byte".into(),
+            U16 => "@com.facebook.serde.Unsigned Short".into(),
+            U32 => "@com.facebook.serde.Unsigned Integer".into(),
+            U64 => "@com.facebook.serde.Unsigned Long".into(),
+            U128 => "@com.facebook.serde.Unsigned @com.facebook.serde.Int128 BigInteger".into(),
+            F32 => "Float".into(),
+            F64 => "Double".into(),
+            Char => "Character".into(),
+            Str => "String".into(),
+            Bytes => "com.facebook.serde.Bytes".into(),
 
-fn output_trait_helpers(
-    out: &mut dyn Write,
-    registry: &Registry,
-    nested_class: bool,
-) -> Result<()> {
-    let mut subtypes = BTreeMap::new();
-    for format in registry.values() {
-        format
-            .visit(&mut |f| {
-                if needs_helper(f) {
-                    subtypes.insert(mangle_type(f), f.clone());
-                }
-                Ok(())
-            })
-            .unwrap();
+            Option(format) => format!(
+                "java.util.Optional<{}>",
+                Self::quote_type(format, package_prefix)
+            ),
+            Seq(format) => format!(
+                "java.util.List<{}>",
+                Self::quote_type(format, package_prefix)
+            ),
+            Map { key, value } => format!(
+                "java.util.Map<{}, {}>",
+                Self::quote_type(key, package_prefix),
+                Self::quote_type(value, package_prefix)
+            ),
+            Tuple(formats) => format!(
+                "com.facebook.serde.Tuple{}<{}>",
+                formats.len(),
+                Self::quote_types(formats, package_prefix)
+            ),
+            TupleArray { content, size } => format!(
+                "{} @com.facebook.serde.ArrayLen(length={}) []",
+                Self::quote_type(content, package_prefix),
+                size
+            ),
+            Variable(_) => panic!("unexpected value"),
+        }
     }
-    let prefix = if nested_class { "static " } else { "" };
-    writeln!(out, "{}final class TraitHelpers {{", prefix)?;
-    for (mangled_name, subtype) in &subtypes {
-        output_serialization_helper(out, mangled_name, subtype)?;
-        output_deserialization_helper(out, mangled_name, subtype)?;
+
+    fn quote_types(formats: &[Format], package_prefix: &str) -> String {
+        formats
+            .iter()
+            .map(|f| Self::quote_type(f, package_prefix))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
-    writeln!(out, "}}\n")
-}
 
-fn mangle_type(format: &Format) -> String {
-    use Format::*;
-    match format {
-        TypeName(x) => x.to_string(),
-        Unit => "unit".into(),
-        Bool => "bool".into(),
-        I8 => "i8".into(),
-        I16 => "i16".into(),
-        I32 => "i32".into(),
-        I64 => "i64".into(),
-        I128 => "i128".into(),
-        U8 => "u8".into(),
-        U16 => "u16".into(),
-        U32 => "u32".into(),
-        U64 => "u64".into(),
-        U128 => "u128".into(),
-        F32 => "f32".into(),
-        F64 => "f64".into(),
-        Char => "char".into(),
-        Str => "str".into(),
-        Bytes => "bytes".into(),
-
-        Option(format) => format!("option_{}", mangle_type(format)),
-        Seq(format) => format!("vector_{}", mangle_type(format)),
-        Map { key, value } => format!("map_{}_to_{}", mangle_type(key), mangle_type(value)),
-        Tuple(formats) => format!(
-            "tuple{}_{}",
-            formats.len(),
-            formats
-                .iter()
-                .map(mangle_type)
-                .collect::<Vec<_>>()
-                .join("_")
-        ),
-        TupleArray { content, size } => format!("array{}_{}_array", size, mangle_type(content)),
-        Variable(_) => panic!("unexpected value"),
+    fn output_trait_helpers(&mut self, registry: &Registry) -> Result<()> {
+        let mut subtypes = BTreeMap::new();
+        for format in registry.values() {
+            format
+                .visit(&mut |f| {
+                    if Self::needs_helper(f) {
+                        subtypes.insert(Self::mangle_type(f), f.clone());
+                    }
+                    Ok(())
+                })
+                .unwrap();
+        }
+        let prefix = if self.nested_class { "static " } else { "" };
+        writeln!(self.out, "{}final class TraitHelpers {{", prefix)?;
+        self.out.inc_level();
+        for (mangled_name, subtype) in &subtypes {
+            self.output_serialization_helper(mangled_name, subtype)?;
+            self.output_deserialization_helper(mangled_name, subtype)?;
+        }
+        self.out.dec_level();
+        writeln!(self.out, "}}\n")
     }
-}
 
-fn needs_helper(format: &Format) -> bool {
-    use Format::*;
-    match format {
-        Option(_) | Seq(_) | Map { .. } | Tuple(_) | TupleArray { .. } => true,
-        _ => false,
-    }
-}
+    fn mangle_type(format: &Format) -> String {
+        use Format::*;
+        match format {
+            TypeName(x) => x.to_string(),
+            Unit => "unit".into(),
+            Bool => "bool".into(),
+            I8 => "i8".into(),
+            I16 => "i16".into(),
+            I32 => "i32".into(),
+            I64 => "i64".into(),
+            I128 => "i128".into(),
+            U8 => "u8".into(),
+            U16 => "u16".into(),
+            U32 => "u32".into(),
+            U64 => "u64".into(),
+            U128 => "u128".into(),
+            F32 => "f32".into(),
+            F64 => "f64".into(),
+            Char => "char".into(),
+            Str => "str".into(),
+            Bytes => "bytes".into(),
 
-fn quote_serialize_value(value: &str, format: &Format) -> String {
-    use Format::*;
-    match format {
-        TypeName(_) => format!("{}.serialize(serializer);", value),
-        Unit => format!("serializer.serialize_unit({});", value),
-        Bool => format!("serializer.serialize_bool({});", value),
-        I8 => format!("serializer.serialize_i8({});", value),
-        I16 => format!("serializer.serialize_i16({});", value),
-        I32 => format!("serializer.serialize_i32({});", value),
-        I64 => format!("serializer.serialize_i64({});", value),
-        I128 => format!("serializer.serialize_i128({});", value),
-        U8 => format!("serializer.serialize_u8({});", value),
-        U16 => format!("serializer.serialize_u16({});", value),
-        U32 => format!("serializer.serialize_u32({});", value),
-        U64 => format!("serializer.serialize_u64({});", value),
-        U128 => format!("serializer.serialize_u128({});", value),
-        F32 => format!("serializer.serialize_f32({});", value),
-        F64 => format!("serializer.serialize_f64({});", value),
-        Char => format!("serializer.serialize_char({});", value),
-        Str => format!("serializer.serialize_str({});", value),
-        Bytes => format!("serializer.serialize_bytes({});", value),
-        _ => format!(
-            "TraitHelpers.serialize_{}({}, serializer);",
-            mangle_type(format),
-            value
-        ),
-    }
-}
-
-fn quote_deserialize(format: &Format, package_prefix: &str) -> String {
-    use Format::*;
-    match format {
-        TypeName(name) => format!("{}{}.deserialize(deserializer)", package_prefix, name),
-        Unit => "deserializer.deserialize_unit()".to_string(),
-        Bool => "deserializer.deserialize_bool()".to_string(),
-        I8 => "deserializer.deserialize_i8()".to_string(),
-        I16 => "deserializer.deserialize_i16()".to_string(),
-        I32 => "deserializer.deserialize_i32()".to_string(),
-        I64 => "deserializer.deserialize_i64()".to_string(),
-        I128 => "deserializer.deserialize_i128()".to_string(),
-        U8 => "deserializer.deserialize_u8()".to_string(),
-        U16 => "deserializer.deserialize_u16()".to_string(),
-        U32 => "deserializer.deserialize_u32()".to_string(),
-        U64 => "deserializer.deserialize_u64()".to_string(),
-        U128 => "deserializer.deserialize_u128()".to_string(),
-        F32 => "deserializer.deserialize_f32()".to_string(),
-        F64 => "deserializer.deserialize_f64()".to_string(),
-        Char => "deserializer.deserialize_char()".to_string(),
-        Str => "deserializer.deserialize_str()".to_string(),
-        Bytes => "deserializer.deserialize_bytes()".to_string(),
-        _ => format!(
-            "TraitHelpers.deserialize_{}(deserializer)",
-            mangle_type(format),
-        ),
-    }
-}
-
-fn output_serialization_helper(out: &mut dyn Write, name: &str, format0: &Format) -> Result<()> {
-    use Format::*;
-
-    write!(
-        out,
-        "    static void serialize_{}({} value, com.facebook.serde.Serializer serializer) throws java.lang.Exception {{",
-        name,
-        quote_type(format0, "")
-    )?;
-    match format0 {
-        Option(format) => {
-            write!(
-                out,
-                r#"
-        if (value.isPresent()) {{
-            serializer.serialize_option_tag(true);
-            {}
-        }} else {{
-            serializer.serialize_option_tag(false);
-        }}
-"#,
-                quote_serialize_value("value.get()", format)
-            )?;
-        }
-
-        Seq(format) => {
-            write!(
-                out,
-                r#"
-        serializer.serialize_len(value.size());
-        for ({} item : value) {{
-            {}
-        }}
-"#,
-                quote_type(format, ""),
-                quote_serialize_value("item", format)
-            )?;
-        }
-
-        Map { key, value } => {
-            write!(
-                out,
-                r#"
-        serializer.serialize_len(value.size());
-        int[] offsets = new int[value.size()];
-        int count = 0;
-        for (java.util.Map.Entry<{}, {}> entry : value.entrySet()) {{
-            offsets[count++] = serializer.get_buffer_offset();
-            {}
-            {}
-        }}
-        serializer.sort_map_entries(offsets);
-"#,
-                quote_type(key, ""),
-                quote_type(value, ""),
-                quote_serialize_value("entry.getKey()", key),
-                quote_serialize_value("entry.getValue()", value)
-            )?;
-        }
-
-        Tuple(formats) => {
-            writeln!(out)?;
-            for (index, format) in formats.iter().enumerate() {
-                let expr = format!("value.field{}", index);
-                writeln!(out, "        {}", quote_serialize_value(&expr, format))?;
-            }
-        }
-
-        TupleArray { content, size } => {
-            write!(
-                out,
-                r#"
-        assert value.length == {};
-        for ({} item : value) {{
-            {}
-        }}
-"#,
-                size,
-                quote_type(content, ""),
-                quote_serialize_value("item", content),
-            )?;
-        }
-
-        _ => panic!("unexpected case"),
-    }
-    writeln!(out, "    }}\n")
-}
-
-fn output_deserialization_helper(out: &mut dyn Write, name: &str, format0: &Format) -> Result<()> {
-    use Format::*;
-
-    write!(
-        out,
-        "    static {} deserialize_{}(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{",
-        quote_type(format0, ""),
-        name,
-    )?;
-    match format0 {
-        Option(format) => {
-            write!(
-                out,
-                r#"
-        boolean tag = deserializer.deserialize_option_tag();
-        if (!tag) {{
-            return java.util.Optional.empty();
-        }} else {{
-            return java.util.Optional.of({});
-        }}
-"#,
-                quote_deserialize(format, "")
-            )?;
-        }
-
-        Seq(format) => {
-            write!(
-                out,
-                r#"
-        long length = deserializer.deserialize_len();
-        java.util.List<{0}> obj = new java.util.ArrayList<{0}>((int) length);
-        for (long i = 0; i < length; i++) {{
-            obj.add({1});
-        }}
-        return obj;
-"#,
-                quote_type(format, ""),
-                quote_deserialize(format, "")
-            )?;
-        }
-
-        Map { key, value } => {
-            write!(
-                out,
-                r#"
-        long length = deserializer.deserialize_len();
-        java.util.Map<{0}, {1}> obj = new java.util.HashMap<{0}, {1}>();
-        int previous_key_start = 0;
-        int previous_key_end = 0;
-        for (long i = 0; i < length; i++) {{
-            int key_start = deserializer.get_buffer_offset();
-            {0} key = {2};
-            int key_end = deserializer.get_buffer_offset();
-            if (i > 0) {{
-                deserializer.check_that_key_slices_are_increasing(
-                    new com.facebook.serde.Slice(previous_key_start, previous_key_end),
-                    new com.facebook.serde.Slice(key_start, key_end));
-            }}
-            previous_key_start = key_start;
-            previous_key_end = key_end;
-            {1} value = {3};
-            obj.put(key, value);
-        }}
-        return obj;
-"#,
-                quote_type(key, ""),
-                quote_type(value, ""),
-                quote_deserialize(key, ""),
-                quote_deserialize(value, ""),
-            )?;
-        }
-
-        Tuple(formats) => {
-            writeln!(
-                out,
-                r#"
-        return new {}({}
-        );
-"#,
-                quote_type(format0, ""),
+            Option(format) => format!("option_{}", Self::mangle_type(format)),
+            Seq(format) => format!("vector_{}", Self::mangle_type(format)),
+            Map { key, value } => format!(
+                "map_{}_to_{}",
+                Self::mangle_type(key),
+                Self::mangle_type(value)
+            ),
+            Tuple(formats) => format!(
+                "tuple{}_{}",
+                formats.len(),
                 formats
                     .iter()
-                    .map(|f| format!("\n            {}", quote_deserialize(f, "")))
+                    .map(Self::mangle_type)
                     .collect::<Vec<_>>()
-                    .join(",")
-            )?;
+                    .join("_")
+            ),
+            TupleArray { content, size } => {
+                format!("array{}_{}_array", size, Self::mangle_type(content))
+            }
+            Variable(_) => panic!("unexpected value"),
         }
-
-        TupleArray { content, size } => {
-            write!(
-                out,
-                r#"
-        {0}[] obj = new {0}[{1}];
-        for (int i = 0; i < {1}; i++) {{
-            obj[i] = {2};
-        }}
-        return obj;
-"#,
-                quote_type(content, ""),
-                size,
-                quote_deserialize(content, "")
-            )?;
-        }
-
-        _ => panic!("unexpected case"),
     }
-    writeln!(out, "    }}\n")
-}
 
-fn output_variant(
-    out: &mut dyn Write,
-    base: &str,
-    index: u32,
-    name: &str,
-    variant: &VariantFormat,
-    package_prefix: &str,
-) -> Result<()> {
-    use VariantFormat::*;
-    let fields = match variant {
-        Unit => Vec::new(),
-        NewType(format) => vec![Named {
-            name: "value".to_string(),
-            value: format.as_ref().clone(),
-        }],
-        Tuple(formats) => formats
-            .iter()
-            .enumerate()
-            .map(|(i, f)| Named {
-                name: format!("field{}", i),
-                value: f.clone(),
-            })
-            .collect(),
-        Struct(fields) => fields.clone(),
-        Variable(_) => panic!("incorrect value"),
-    };
-    output_struct_or_variant_container(
-        out,
-        4,
-        Some(base),
-        Some(index),
+    fn needs_helper(format: &Format) -> bool {
+        use Format::*;
+        match format {
+            Option(_) | Seq(_) | Map { .. } | Tuple(_) | TupleArray { .. } => true,
+            _ => false,
+        }
+    }
+
+    fn quote_serialize_value(value: &str, format: &Format) -> String {
+        use Format::*;
+        match format {
+            TypeName(_) => format!("{}.serialize(serializer);", value),
+            Unit => format!("serializer.serialize_unit({});", value),
+            Bool => format!("serializer.serialize_bool({});", value),
+            I8 => format!("serializer.serialize_i8({});", value),
+            I16 => format!("serializer.serialize_i16({});", value),
+            I32 => format!("serializer.serialize_i32({});", value),
+            I64 => format!("serializer.serialize_i64({});", value),
+            I128 => format!("serializer.serialize_i128({});", value),
+            U8 => format!("serializer.serialize_u8({});", value),
+            U16 => format!("serializer.serialize_u16({});", value),
+            U32 => format!("serializer.serialize_u32({});", value),
+            U64 => format!("serializer.serialize_u64({});", value),
+            U128 => format!("serializer.serialize_u128({});", value),
+            F32 => format!("serializer.serialize_f32({});", value),
+            F64 => format!("serializer.serialize_f64({});", value),
+            Char => format!("serializer.serialize_char({});", value),
+            Str => format!("serializer.serialize_str({});", value),
+            Bytes => format!("serializer.serialize_bytes({});", value),
+            _ => format!(
+                "TraitHelpers.serialize_{}({}, serializer);",
+                Self::mangle_type(format),
+                value
+            ),
+        }
+    }
+
+    fn quote_deserialize(format: &Format, package_prefix: &str) -> String {
+        use Format::*;
+        match format {
+            TypeName(name) => format!("{}{}.deserialize(deserializer)", package_prefix, name),
+            Unit => "deserializer.deserialize_unit()".to_string(),
+            Bool => "deserializer.deserialize_bool()".to_string(),
+            I8 => "deserializer.deserialize_i8()".to_string(),
+            I16 => "deserializer.deserialize_i16()".to_string(),
+            I32 => "deserializer.deserialize_i32()".to_string(),
+            I64 => "deserializer.deserialize_i64()".to_string(),
+            I128 => "deserializer.deserialize_i128()".to_string(),
+            U8 => "deserializer.deserialize_u8()".to_string(),
+            U16 => "deserializer.deserialize_u16()".to_string(),
+            U32 => "deserializer.deserialize_u32()".to_string(),
+            U64 => "deserializer.deserialize_u64()".to_string(),
+            U128 => "deserializer.deserialize_u128()".to_string(),
+            F32 => "deserializer.deserialize_f32()".to_string(),
+            F64 => "deserializer.deserialize_f64()".to_string(),
+            Char => "deserializer.deserialize_char()".to_string(),
+            Str => "deserializer.deserialize_str()".to_string(),
+            Bytes => "deserializer.deserialize_bytes()".to_string(),
+            _ => format!(
+                "TraitHelpers.deserialize_{}(deserializer)",
+                Self::mangle_type(format),
+            ),
+        }
+    }
+
+    fn output_serialization_helper(&mut self, name: &str, format0: &Format) -> Result<()> {
+        use Format::*;
+
+        write!(
+        self.out,
+        "static void serialize_{}({} value, com.facebook.serde.Serializer serializer) throws java.lang.Exception {{",
         name,
-        &fields,
-        false,
-        package_prefix,
-    )
-}
+        Self::quote_type(format0, "")
+    )?;
+        self.out.inc_level();
+        match format0 {
+            Option(format) => {
+                write!(
+                    self.out,
+                    r#"
+if (value.isPresent()) {{
+    serializer.serialize_option_tag(true);
+    {}
+}} else {{
+    serializer.serialize_option_tag(false);
+}}
+"#,
+                    Self::quote_serialize_value("value.get()", format)
+                )?;
+            }
 
-fn output_variants(
-    out: &mut dyn Write,
-    base: &str,
-    variants: &BTreeMap<u32, Named<VariantFormat>>,
-    package_prefix: &str,
-) -> Result<()> {
-    for (index, variant) in variants {
-        output_variant(
-            out,
-            base,
-            *index,
-            &variant.name,
-            &variant.value,
-            package_prefix,
-        )?;
+            Seq(format) => {
+                write!(
+                    self.out,
+                    r#"
+serializer.serialize_len(value.size());
+for ({} item : value) {{
+    {}
+}}
+"#,
+                    Self::quote_type(format, ""),
+                    Self::quote_serialize_value("item", format)
+                )?;
+            }
+
+            Map { key, value } => {
+                write!(
+                    self.out,
+                    r#"
+serializer.serialize_len(value.size());
+int[] offsets = new int[value.size()];
+int count = 0;
+for (java.util.Map.Entry<{}, {}> entry : value.entrySet()) {{
+    offsets[count++] = serializer.get_buffer_offset();
+    {}
+    {}
+}}
+serializer.sort_map_entries(offsets);
+"#,
+                    Self::quote_type(key, ""),
+                    Self::quote_type(value, ""),
+                    Self::quote_serialize_value("entry.getKey()", key),
+                    Self::quote_serialize_value("entry.getValue()", value)
+                )?;
+            }
+
+            Tuple(formats) => {
+                writeln!(self.out)?;
+                for (index, format) in formats.iter().enumerate() {
+                    let expr = format!("value.field{}", index);
+                    writeln!(self.out, "{}", Self::quote_serialize_value(&expr, format))?;
+                }
+            }
+
+            TupleArray { content, size } => {
+                write!(
+                    self.out,
+                    r#"
+assert value.length == {};
+for ({} item : value) {{
+    {}
+}}
+"#,
+                    size,
+                    Self::quote_type(content, ""),
+                    Self::quote_serialize_value("item", content),
+                )?;
+            }
+
+            _ => panic!("unexpected case"),
+        }
+        self.out.dec_level();
+        writeln!(self.out, "}}\n")
     }
-    Ok(())
-}
 
-#[allow(clippy::too_many_arguments)]
-fn output_struct_or_variant_container(
-    out: &mut dyn Write,
-    indentation: usize,
-    variant_base: Option<&str>,
-    variant_index: Option<u32>,
-    name: &str,
-    fields: &[Named<Format>],
-    nested_class: bool,
-    package_prefix: &str,
-) -> Result<()> {
-    let mut out = IndentedWriter::new(out, IndentConfig::Space(4));
-    out.set_level(indentation / 4);
-    // Beginning of class
-    if let Some(base) = variant_base {
-        writeln!(out)?;
+    fn output_deserialization_helper(&mut self, name: &str, format0: &Format) -> Result<()> {
+        use Format::*;
+
+        write!(
+        self.out,
+        "static {} deserialize_{}(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{",
+        Self::quote_type(format0, ""),
+        name,
+    )?;
+        self.out.inc_level();
+        match format0 {
+            Option(format) => {
+                write!(
+                    self.out,
+                    r#"
+boolean tag = deserializer.deserialize_option_tag();
+if (!tag) {{
+    return java.util.Optional.empty();
+}} else {{
+    return java.util.Optional.of({});
+}}
+"#,
+                    Self::quote_deserialize(format, "")
+                )?;
+            }
+
+            Seq(format) => {
+                write!(
+                    self.out,
+                    r#"
+long length = deserializer.deserialize_len();
+java.util.List<{0}> obj = new java.util.ArrayList<{0}>((int) length);
+for (long i = 0; i < length; i++) {{
+    obj.add({1});
+}}
+return obj;
+"#,
+                    Self::quote_type(format, ""),
+                    Self::quote_deserialize(format, "")
+                )?;
+            }
+
+            Map { key, value } => {
+                write!(
+                    self.out,
+                    r#"
+long length = deserializer.deserialize_len();
+java.util.Map<{0}, {1}> obj = new java.util.HashMap<{0}, {1}>();
+int previous_key_start = 0;
+int previous_key_end = 0;
+for (long i = 0; i < length; i++) {{
+    int key_start = deserializer.get_buffer_offset();
+    {0} key = {2};
+    int key_end = deserializer.get_buffer_offset();
+    if (i > 0) {{
+        deserializer.check_that_key_slices_are_increasing(
+            new com.facebook.serde.Slice(previous_key_start, previous_key_end),
+            new com.facebook.serde.Slice(key_start, key_end));
+    }}
+    previous_key_start = key_start;
+    previous_key_end = key_end;
+    {1} value = {3};
+    obj.put(key, value);
+}}
+return obj;
+"#,
+                    Self::quote_type(key, ""),
+                    Self::quote_type(value, ""),
+                    Self::quote_deserialize(key, ""),
+                    Self::quote_deserialize(value, ""),
+                )?;
+            }
+
+            Tuple(formats) => {
+                write!(
+                    self.out,
+                    r#"
+return new {}({}
+);
+"#,
+                    Self::quote_type(format0, ""),
+                    formats
+                        .iter()
+                        .map(|f| format!("\n    {}", Self::quote_deserialize(f, "")))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )?;
+            }
+
+            TupleArray { content, size } => {
+                write!(
+                    self.out,
+                    r#"
+{0}[] obj = new {0}[{1}];
+for (int i = 0; i < {1}; i++) {{
+    obj[i] = {2};
+}}
+return obj;
+"#,
+                    Self::quote_type(content, ""),
+                    size,
+                    Self::quote_deserialize(content, "")
+                )?;
+            }
+
+            _ => panic!("unexpected case"),
+        }
+        self.out.dec_level();
+        writeln!(self.out, "}}\n")
+    }
+
+    fn output_variant(
+        &mut self,
+        base: &str,
+        index: u32,
+        name: &str,
+        variant: &VariantFormat,
+    ) -> Result<()> {
+        use VariantFormat::*;
+        let fields = match variant {
+            Unit => Vec::new(),
+            NewType(format) => vec![Named {
+                name: "value".to_string(),
+                value: format.as_ref().clone(),
+            }],
+            Tuple(formats) => formats
+                .iter()
+                .enumerate()
+                .map(|(i, f)| Named {
+                    name: format!("field{}", i),
+                    value: f.clone(),
+                })
+                .collect(),
+            Struct(fields) => fields.clone(),
+            Variable(_) => panic!("incorrect value"),
+        };
+        self.output_struct_or_variant_container(Some(base), Some(index), name, &fields)
+    }
+
+    fn output_variants(
+        &mut self,
+        base: &str,
+        variants: &BTreeMap<u32, Named<VariantFormat>>,
+    ) -> Result<()> {
+        for (index, variant) in variants {
+            self.output_variant(base, *index, &variant.name, &variant.value)?;
+        }
+        Ok(())
+    }
+
+    fn output_struct_or_variant_container(
+        &mut self,
+        variant_base: Option<&str>,
+        variant_index: Option<u32>,
+        name: &str,
+        fields: &[Named<Format>],
+    ) -> Result<()> {
+        // Beginning of class
+        if let Some(base) = variant_base {
+            writeln!(self.out)?;
+            writeln!(
+                self.out,
+                "public static final class {} extends {} {{",
+                name, base
+            )?;
+        } else {
+            let prefix = if self.nested_class {
+                "public static "
+            } else {
+                "public "
+            };
+            writeln!(self.out, "{}final class {} {{", prefix, name)?;
+        }
+        self.out.inc_level();
+        // Fields
+        for field in fields {
+            writeln!(
+                self.out,
+                "public final {} {};",
+                Self::quote_type(&field.value, &self.package_prefix),
+                field.name
+            )?;
+        }
+        if !fields.is_empty() {
+            writeln!(self.out)?;
+        }
+        // Constructor.
         writeln!(
-            out,
-            "public static final class {} extends {} {{",
-            name, base
+            self.out,
+            "public {}({}) {{",
+            name,
+            fields
+                .iter()
+                .map(|f| format!(
+                    "{} {}",
+                    Self::quote_type(&f.value, &self.package_prefix),
+                    &f.name
+                ))
+                .collect::<Vec<_>>()
+                .join(", ")
         )?;
-    } else {
-        let prefix = if nested_class {
+        self.out.inc_level();
+        for field in fields {
+            writeln!(self.out, "assert {} != null;", &field.name)?;
+        }
+        for field in fields {
+            writeln!(self.out, "this.{} = {};", &field.name, &field.name)?;
+        }
+        self.out.dec_level();
+        writeln!(self.out, "}}")?;
+        // Serialize
+        writeln!(
+        self.out,
+        "\npublic void serialize(com.facebook.serde.Serializer serializer) throws java.lang.Exception {{",
+    )?;
+        self.out.inc_level();
+        if let Some(index) = variant_index {
+            writeln!(self.out, "serializer.serialize_variant_index({});", index)?;
+        }
+        for field in fields {
+            writeln!(
+                self.out,
+                "{}",
+                Self::quote_serialize_value(&field.name, &field.value)
+            )?;
+        }
+        self.out.dec_level();
+        writeln!(self.out, "}}\n")?;
+        // Deserialize (struct) or Load (variant)
+        if variant_index.is_none() {
+            writeln!(
+            self.out,
+            "public static {} deserialize(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{",
+            name,
+        )?;
+        } else {
+            writeln!(
+            self.out,
+            "static {} load(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{",
+            name,
+        )?;
+        }
+        self.out.inc_level();
+        writeln!(self.out, "Builder builder = new Builder();")?;
+        for field in fields {
+            writeln!(
+                self.out,
+                "builder.{} = {};",
+                field.name,
+                Self::quote_deserialize(&field.value, &self.package_prefix)
+            )?;
+        }
+        writeln!(self.out, "return builder.build();")?;
+        self.out.dec_level();
+        writeln!(self.out, "}}\n")?;
+        // Equality
+        write!(self.out, "public boolean equals(Object obj) {{")?;
+        self.out.inc_level();
+        writeln!(
+            self.out,
+            r#"
+if (this == obj) return true;
+if (obj == null) return false;
+if (getClass() != obj.getClass()) return false;
+{0} other = ({0}) obj;"#,
+            name,
+        )?;
+        for field in fields {
+            writeln!(
+                self.out,
+                "if (!java.util.Objects.equals(this.{0}, other.{0})) {{ return false; }}",
+                &field.name,
+            )?;
+        }
+        writeln!(self.out, "return true;")?;
+        self.out.dec_level();
+        writeln!(self.out, "}}\n")?;
+        // Hashing
+        writeln!(self.out, "public int hashCode() {{")?;
+        self.out.inc_level();
+        writeln!(self.out, "int value = 7;",)?;
+        for field in fields {
+            writeln!(
+                self.out,
+                "value = 31 * value + (this.{0} != null ? this.{0}.hashCode() : 0);",
+                &field.name
+            )?;
+        }
+        writeln!(self.out, "return value;")?;
+        self.out.dec_level();
+        writeln!(self.out, "}}")?;
+        // Builder
+        self.output_struct_or_variant_container_builder(name, fields)?;
+        // End of class
+        self.out.dec_level();
+        writeln!(self.out, "}}")
+    }
+
+    fn output_struct_or_variant_container_builder(
+        &mut self,
+        name: &str,
+        fields: &[Named<Format>],
+    ) -> Result<()> {
+        // Beginning of builder class
+        writeln!(self.out)?;
+        writeln!(self.out, "public static final class Builder {{")?;
+        self.out.inc_level();
+        // Fields
+        for field in fields {
+            writeln!(
+                self.out,
+                "public {} {};",
+                Self::quote_type(&field.value, &self.package_prefix),
+                field.name
+            )?;
+        }
+        if !fields.is_empty() {
+            writeln!(self.out)?;
+        }
+        // Finalization
+        writeln!(
+            self.out,
+            r#"public {0} build() {{
+    return new {0}({1}
+    );
+}}"#,
+            name,
+            fields
+                .iter()
+                .map(|f| format!("\n        {}", f.name))
+                .collect::<Vec<_>>()
+                .join(",")
+        )?;
+        // End of class
+        self.out.dec_level();
+        writeln!(self.out, "}}")
+    }
+
+    fn output_enum_container(
+        &mut self,
+        name: &str,
+        variants: &BTreeMap<u32, Named<VariantFormat>>,
+    ) -> Result<()> {
+        let prefix = if self.nested_class {
             "public static "
         } else {
             "public "
         };
-        writeln!(out, "{}final class {} {{", prefix, name)?;
-    }
-    // Fields
-    for field in fields {
+        writeln!(self.out, "{}abstract class {} {{", prefix, name)?;
+        self.out.inc_level();
         writeln!(
-            out,
-            "    public final {} {};",
-            quote_type(&field.value, package_prefix),
-            field.name
-        )?;
-    }
-    if !fields.is_empty() {
-        writeln!(out)?;
-    }
-    // Constructor.
-    writeln!(
-        out,
-        "    public {}({}) {{",
-        name,
-        fields
-            .iter()
-            .map(|f| format!("{} {}", quote_type(&f.value, package_prefix), &f.name))
-            .collect::<Vec<_>>()
-            .join(", ")
+        self.out,
+        "abstract public void serialize(com.facebook.serde.Serializer serializer) throws java.lang.Exception;\n",
     )?;
-    for field in fields {
-        writeln!(out, "       assert {} != null;", &field.name)?;
-    }
-    for field in fields {
-        writeln!(out, "       this.{} = {};", &field.name, &field.name)?;
-    }
-    writeln!(out, "    }}")?;
-    // Serialize
-    writeln!(
-        out,
-        "\n    public void serialize(com.facebook.serde.Serializer serializer) throws java.lang.Exception {{",
-    )?;
-    if let Some(index) = variant_index {
+        write!(
+        self.out,
+        "public static {} deserialize(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{", name)?;
+        self.out.inc_level();
         writeln!(
-            out,
-            "        serializer.serialize_variant_index({});",
-            index
-        )?;
-    }
-    for field in fields {
-        writeln!(
-            out,
-            "        {}",
-            quote_serialize_value(&field.name, &field.value)
-        )?;
-    }
-    writeln!(out, "    }}\n")?;
-    // Deserialize (struct) or Load (variant)
-    if variant_index.is_none() {
-        writeln!(
-            out,
-            "    public static {} deserialize(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{",
+            self.out,
+            r#"
+{} obj;
+int index = deserializer.deserialize_variant_index();
+switch (index) {{"#,
             name,
         )?;
-    } else {
-        writeln!(
-            out,
-            "    static {} load(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{",
-            name,
-        )?;
-    }
-    writeln!(out, "        Builder builder = new Builder();")?;
-    for field in fields {
-        writeln!(
-            out,
-            "        builder.{} = {};",
-            field.name,
-            quote_deserialize(&field.value, package_prefix)
-        )?;
-    }
-    writeln!(out, "        return builder.build();")?;
-    writeln!(out, "    }}\n")?;
-    // Equality
-    writeln!(
-        out,
-        r#"    public boolean equals(Object obj) {{
-        if (this == obj) return true;
-        if (obj == null) return false;
-        if (getClass() != obj.getClass()) return false;
-        {0} other = ({0}) obj;"#,
-        name,
-    )?;
-    for field in fields {
-        writeln!(
-            out,
-            "        if (!java.util.Objects.equals(this.{0}, other.{0})) {{ return false; }}",
-            &field.name,
-        )?;
-    }
-    writeln!(out, "        return true;")?;
-    writeln!(out, "    }}\n")?;
-    // Hashing
-    writeln!(out, "    public int hashCode() {{\n        int value = 7;",)?;
-    for field in fields {
-        writeln!(
-            out,
-            "        value = 31 * value + (this.{0} != null ? this.{0}.hashCode() : 0);",
-            &field.name
-        )?;
-    }
-    writeln!(out, "        return value;")?;
-    writeln!(out, "    }}")?;
-    // Builder
-    out.inc_level();
-    output_struct_or_variant_container_builder(&mut out, name, fields, package_prefix)?;
-    out.dec_level();
-    // End of class
-    writeln!(out, "}}")
-}
-
-#[allow(clippy::too_many_arguments)]
-fn output_struct_or_variant_container_builder(
-    out: &mut IndentedWriter<&mut dyn Write>,
-    name: &str,
-    fields: &[Named<Format>],
-    package_prefix: &str,
-) -> Result<()> {
-    // Beginning of builder class
-    writeln!(out)?;
-    writeln!(out, "public static final class Builder {{")?;
-    // Fields
-    for field in fields {
-        writeln!(
-            out,
-            "    public {} {};",
-            quote_type(&field.value, package_prefix),
-            field.name
-        )?;
-    }
-    if !fields.is_empty() {
-        writeln!(out)?;
-    }
-    // Finalization
-    writeln!(
-        out,
-        r#"    public {0} build() {{
-        return new {0}({1}
-        );
-    }}"#,
-        name,
-        fields
-            .iter()
-            .map(|f| format!("\n            {}", f.name))
-            .collect::<Vec<_>>()
-            .join(",")
-    )?;
-    // End of class
-    writeln!(out, "}}")
-}
-
-fn output_enum_container(
-    out: &mut dyn Write,
-    name: &str,
-    variants: &BTreeMap<u32, Named<VariantFormat>>,
-    nested_class: bool,
-    package_prefix: &str,
-) -> Result<()> {
-    let prefix = if nested_class {
-        "public static "
-    } else {
-        "public "
-    };
-    writeln!(out, "{}abstract class {} {{", prefix, name)?;
-    writeln!(
-        out,
-        "    abstract public void serialize(com.facebook.serde.Serializer serializer) throws java.lang.Exception;",
-    )?;
-    write!(
-        out,
-        r#"
-    public static {0} deserialize(com.facebook.serde.Deserializer deserializer) throws java.lang.Exception {{
-        {0} obj;
-        int index = deserializer.deserialize_variant_index();
-        switch (index) {{
-"#,
-        name,
-    )?;
-    for (index, variant) in variants {
-        writeln!(
-            out,
-            "            case {}: return {}.load(deserializer);",
-            index, variant.name,
-        )?;
-    }
-    writeln!(
-        out,
-        "            default: throw new java.lang.Exception(\"Unknown variant index for {}: \" + index);",
-        name,
-    )?;
-    writeln!(out, "        }}")?;
-    writeln!(out, "    }}")?;
-    output_variants(out, name, variants, package_prefix)?;
-    writeln!(out, "}}\n")
-}
-
-fn output_container(
-    out: &mut dyn Write,
-    name: &str,
-    format: &ContainerFormat,
-    nested_class: bool,
-    package_prefix: &str,
-) -> Result<()> {
-    use ContainerFormat::*;
-    let fields = match format {
-        UnitStruct => Vec::new(),
-        NewTypeStruct(format) => vec![Named {
-            name: "value".to_string(),
-            value: format.as_ref().clone(),
-        }],
-        TupleStruct(formats) => formats
-            .iter()
-            .enumerate()
-            .map(|(i, f)| Named {
-                name: format!("field{}", i),
-                value: f.clone(),
-            })
-            .collect::<Vec<_>>(),
-        Struct(fields) => fields.clone(),
-        Enum(variants) => {
-            return output_enum_container(out, name, variants, nested_class, package_prefix);
+        self.out.inc_level();
+        for (index, variant) in variants {
+            writeln!(
+                self.out,
+                "case {}: return {}.load(deserializer);",
+                index, variant.name,
+            )?;
         }
-    };
-    output_struct_or_variant_container(
-        out,
-        0,
-        None,
-        None,
-        name,
-        &fields,
-        nested_class,
-        package_prefix,
-    )
+        writeln!(
+            self.out,
+            "default: throw new java.lang.Exception(\"Unknown variant index for {}: \" + index);",
+            name,
+        )?;
+        self.out.dec_level();
+        writeln!(self.out, "}}")?;
+        self.out.dec_level();
+        writeln!(self.out, "}}")?;
+        self.output_variants(name, variants)?;
+        self.out.dec_level();
+        writeln!(self.out, "}}\n")
+    }
+
+    fn output_container(&mut self, name: &str, format: &ContainerFormat) -> Result<()> {
+        use ContainerFormat::*;
+        let fields = match format {
+            UnitStruct => Vec::new(),
+            NewTypeStruct(format) => vec![Named {
+                name: "value".to_string(),
+                value: format.as_ref().clone(),
+            }],
+            TupleStruct(formats) => formats
+                .iter()
+                .enumerate()
+                .map(|(i, f)| Named {
+                    name: format!("field{}", i),
+                    value: f.clone(),
+                })
+                .collect::<Vec<_>>(),
+            Struct(fields) => fields.clone(),
+            Enum(variants) => {
+                self.output_enum_container(name, variants)?;
+                return Ok(());
+            }
+        };
+        self.output_struct_or_variant_container(None, None, name, &fields)
+    }
 }
 
 pub struct Installer {

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -10,11 +10,7 @@ use std::path::PathBuf;
 /// * The packages `dataclasses` and `typing` are assumed to be available.
 /// * The module `serde_types` is assumed to be available.
 pub fn output(out: &mut dyn Write, registry: &Registry) -> Result<()> {
-    output_preamble(out, None)?;
-    for (name, format) in registry {
-        output_container(out, name, format)?;
-    }
-    Ok(())
+    output_with_optional_serde_package(out, registry, None)
 }
 
 fn output_with_optional_serde_package(
@@ -22,168 +18,200 @@ fn output_with_optional_serde_package(
     registry: &Registry,
     serde_package_name: Option<String>,
 ) -> Result<()> {
-    output_preamble(out, serde_package_name)?;
+    let mut emitter = PythonEmitter {
+        out,
+        indentation: 0,
+        serde_package_name,
+    };
+    emitter.output_preamble()?;
     for (name, format) in registry {
-        output_container(out, name, format)?;
+        emitter.output_container(name, format)?;
     }
     Ok(())
 }
 
-fn output_preamble(out: &mut dyn Write, serde_package_name: Option<String>) -> Result<()> {
-    writeln!(
-        out,
-        r#"from dataclasses import dataclass
+struct PythonEmitter<T> {
+    out: T,
+    indentation: usize,
+    serde_package_name: Option<String>,
+}
+
+impl<T> PythonEmitter<T>
+where
+    T: Write,
+{
+    fn output_preamble(&mut self) -> Result<()> {
+        assert_eq!(self.indentation, 0);
+        writeln!(
+            self.out,
+            r#"from dataclasses import dataclass
 import typing
 {}import serde_types as st"#,
-        match serde_package_name {
-            None => "".to_string(),
-            Some(name) => format!("from {} ", name),
+            match &self.serde_package_name {
+                None => "".to_string(),
+                Some(name) => format!("from {} ", name),
+            }
+        )
+    }
+
+    fn quote_type(format: &Format) -> String {
+        use Format::*;
+        match format {
+            TypeName(x) => format!("\"{}\"", x), // Need quotes because of circular dependencies.
+            Unit => "st.unit".into(),
+            Bool => "st.bool".into(),
+            I8 => "st.int8".into(),
+            I16 => "st.int16".into(),
+            I32 => "st.int32".into(),
+            I64 => "st.int64".into(),
+            I128 => "st.int128".into(),
+            U8 => "st.uint8".into(),
+            U16 => "st.uint16".into(),
+            U32 => "st.uint32".into(),
+            U64 => "st.uint64".into(),
+            U128 => "st.uint128".into(),
+            F32 => "st.float32".into(),
+            F64 => "st.float64".into(),
+            Char => "st.char".into(),
+            Str => "str".into(),
+            Bytes => "bytes".into(),
+
+            Option(format) => format!("typing.Optional[{}]", Self::quote_type(format)),
+            Seq(format) => format!("typing.Sequence[{}]", Self::quote_type(format)),
+            Map { key, value } => format!(
+                "typing.Dict[{}, {}]",
+                Self::quote_type(key),
+                Self::quote_type(value)
+            ),
+            Tuple(formats) => format!("typing.Tuple[{}]", Self::quote_types(formats)),
+            TupleArray { content, size } => format!(
+                "typing.Tuple[{}]",
+                Self::quote_types(&vec![content.as_ref().clone(); *size])
+            ), // Sadly, there are no fixed-size arrays in python.
+
+            Variable(_) => panic!("unexpected value"),
         }
-    )
-}
-
-fn quote_type(format: &Format) -> String {
-    use Format::*;
-    match format {
-        TypeName(x) => format!("\"{}\"", x), // Need quotes because of circular dependencies.
-        Unit => "st.unit".into(),
-        Bool => "st.bool".into(),
-        I8 => "st.int8".into(),
-        I16 => "st.int16".into(),
-        I32 => "st.int32".into(),
-        I64 => "st.int64".into(),
-        I128 => "st.int128".into(),
-        U8 => "st.uint8".into(),
-        U16 => "st.uint16".into(),
-        U32 => "st.uint32".into(),
-        U64 => "st.uint64".into(),
-        U128 => "st.uint128".into(),
-        F32 => "st.float32".into(),
-        F64 => "st.float64".into(),
-        Char => "st.char".into(),
-        Str => "str".into(),
-        Bytes => "bytes".into(),
-
-        Option(format) => format!("typing.Optional[{}]", quote_type(format)),
-        Seq(format) => format!("typing.Sequence[{}]", quote_type(format)),
-        Map { key, value } => format!("typing.Dict[{}, {}]", quote_type(key), quote_type(value)),
-        Tuple(formats) => format!("typing.Tuple[{}]", quote_types(formats)),
-        TupleArray { content, size } => format!(
-            "typing.Tuple[{}]",
-            quote_types(&vec![content.as_ref().clone(); *size])
-        ), // Sadly, there are no fixed-size arrays in python.
-
-        Variable(_) => panic!("unexpected value"),
     }
-}
 
-fn quote_types(formats: &[Format]) -> String {
-    formats
-        .iter()
-        .map(quote_type)
-        .collect::<Vec<_>>()
-        .join(", ")
-}
-
-fn output_fields(out: &mut dyn Write, indentation: usize, fields: &[Named<Format>]) -> Result<()> {
-    let tab = " ".repeat(indentation);
-    for field in fields {
-        writeln!(out, "{}{}: {}", tab, field.name, quote_type(&field.value))?;
+    fn quote_types(formats: &[Format]) -> String {
+        formats
+            .iter()
+            .map(Self::quote_type)
+            .collect::<Vec<_>>()
+            .join(", ")
     }
-    Ok(())
-}
 
-fn output_variant(
-    out: &mut dyn Write,
-    base: &str,
-    name: &str,
-    index: u32,
-    variant: &VariantFormat,
-) -> Result<()> {
-    use VariantFormat::*;
-    match variant {
-        Unit => writeln!(
-            out,
-            "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}\n",
-            base, name, base, index,
-        ),
-        NewType(format) => writeln!(
-            out,
-            "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}\n    value: {}\n",
-            base,
-            name,
-            base,
-            index,
-            quote_type(format)
-        ),
-        Tuple(formats) => writeln!(
-            out,
-            "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}\n    value: typing.Tuple[{}]\n",
-            base,
-            name,
-            base,
-            index,
-            quote_types(formats)
-        ),
-        Struct(fields) => {
+    fn output_fields(&mut self, fields: &[Named<Format>]) -> Result<()> {
+        self.indentation += 1;
+        let tab = "    ".repeat(self.indentation);
+        for field in fields {
             writeln!(
-                out,
-                "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}",
-                base, name, base, index
+                self.out,
+                "{}{}: {}",
+                tab,
+                field.name,
+                Self::quote_type(&field.value)
             )?;
-            output_fields(out, 4, fields)?;
-            writeln!(out)
         }
-        Variable(_) => panic!("incorrect value"),
+        self.indentation -= 1;
+        Ok(())
     }
-}
 
-fn output_variants(
-    out: &mut dyn Write,
-    base: &str,
-    variants: &BTreeMap<u32, Named<VariantFormat>>,
-) -> Result<()> {
-    for (index, variant) in variants {
-        output_variant(out, base, &variant.name, *index, &variant.value)?;
-    }
-    Ok(())
-}
-
-fn output_container(out: &mut dyn Write, name: &str, format: &ContainerFormat) -> Result<()> {
-    use ContainerFormat::*;
-    match format {
-        UnitStruct => writeln!(out, "\n@dataclass\nclass {}:\n    pass\n", name),
-        NewTypeStruct(format) => writeln!(
-            out,
-            "\n@dataclass\nclass {}:\n    value: {}\n",
-            name,
-            quote_type(format)
-        ),
-        TupleStruct(formats) => writeln!(
-            out,
-            "\n@dataclass\nclass {}:\n    value: typing.Tuple[{}]\n",
-            name,
-            quote_types(formats)
-        ),
-        Struct(fields) => {
-            writeln!(out, "\n@dataclass\nclass {}:", name)?;
-            output_fields(out, 4, fields)?;
-            writeln!(out)
-        }
-        Enum(variants) => {
-            // Initializing VARIANTS with a temporary value for typechecking purposes.
-            writeln!(out, "\nclass {}:\n    VARIANTS = []\n", name)?;
-            output_variants(out, name, variants)?;
-            writeln!(
-                out,
-                "{}.VARIANTS = [\n{}]\n",
+    fn output_variant(
+        &mut self,
+        base: &str,
+        name: &str,
+        index: u32,
+        variant: &VariantFormat,
+    ) -> Result<()> {
+        assert_eq!(self.indentation, 0);
+        use VariantFormat::*;
+        match variant {
+            Unit => writeln!(
+                self.out,
+                "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}\n",
+                base, name, base, index,
+            ),
+            NewType(format) => writeln!(
+                self.out,
+                "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}\n    value: {}\n",
+                base,
                 name,
-                variants
-                    .iter()
-                    .map(|(_, v)| format!("    {}__{},\n", name, v.name))
-                    .collect::<Vec<_>>()
-                    .join("")
-            )
+                base,
+                index,
+                Self::quote_type(format)
+            ),
+            Tuple(formats) => writeln!(
+                self.out,
+                "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}\n    value: typing.Tuple[{}]\n",
+                base,
+                name,
+                base,
+                index,
+                Self::quote_types(formats)
+            ),
+            Struct(fields) => {
+                writeln!(
+                    self.out,
+                    "\n@dataclass\nclass {}__{}({}):\n    INDEX = {}",
+                    base, name, base, index
+                )?;
+                self.output_fields(fields)?;
+                writeln!(self.out)
+            }
+            Variable(_) => panic!("incorrect value"),
+        }
+    }
+
+    fn output_variants(
+        &mut self,
+        base: &str,
+        variants: &BTreeMap<u32, Named<VariantFormat>>,
+    ) -> Result<()> {
+        assert_eq!(self.indentation, 0);
+        for (index, variant) in variants {
+            self.output_variant(base, &variant.name, *index, &variant.value)?;
+        }
+        Ok(())
+    }
+
+    fn output_container(&mut self, name: &str, format: &ContainerFormat) -> Result<()> {
+        assert_eq!(self.indentation, 0);
+        use ContainerFormat::*;
+        match format {
+            UnitStruct => writeln!(self.out, "\n@dataclass\nclass {}:\n    pass\n", name),
+            NewTypeStruct(format) => writeln!(
+                self.out,
+                "\n@dataclass\nclass {}:\n    value: {}\n",
+                name,
+                Self::quote_type(format)
+            ),
+            TupleStruct(formats) => writeln!(
+                self.out,
+                "\n@dataclass\nclass {}:\n    value: typing.Tuple[{}]\n",
+                name,
+                Self::quote_types(formats)
+            ),
+            Struct(fields) => {
+                writeln!(self.out, "\n@dataclass\nclass {}:", name)?;
+                self.output_fields(fields)?;
+                writeln!(self.out)
+            }
+            Enum(variants) => {
+                // Initializing VARIANTS with a temporary value for typechecking purposes.
+                writeln!(self.out, "\nclass {}:\n    VARIANTS = []\n", name)?;
+                self.output_variants(name, variants)?;
+                writeln!(
+                    self.out,
+                    "{}.VARIANTS = [\n{}]\n",
+                    name,
+                    variants
+                        .iter()
+                        .map(|(_, v)| format!("    {}__{},\n", name, v.name))
+                        .collect::<Vec<_>>()
+                        .join("")
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

* Refactor the code to introduce a shared state in each language and avoid long lists of parameters in codegen functions
* Use new library https://github.com/facebookincubator/serde-reflection/pull/31 for indenting code.

## Test Plan

unit tests + inspect outputs for each language with
```
cargo run -p serde-generate -- --module-name Libra --language rust <(curl https://raw.githubusercontent.com/libra/libra/master/testsuite/generate-format/tests/staged/consensus.yaml)  | less
```