### PR TITLE
[Serde generate] improve python codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bincode",
  "heck",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.10.0"
+version = "0.11.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -56,6 +56,7 @@ config.output(&mut source, &registry)?;
 assert_eq!(
     String::from_utf8_lossy(&source),
     r#"
+# pyre-strict
 from dataclasses import dataclass
 import typing
 import serde_types as st

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -53,6 +53,7 @@
 //! #  "\n".to_string() + &
 //!     String::from_utf8_lossy(&source),
 //!     r#"
+//! ## pyre-strict
 //! from dataclasses import dataclass
 //! import typing
 //! import serde_types as st

--- a/serde-generate/tests/cli.rs
+++ b/serde-generate/tests/cli.rs
@@ -38,14 +38,13 @@ fn test_that_installed_python_code_parses() {
         std::env::var("PYTHONPATH").unwrap_or_default(),
         dir.path().to_string_lossy(),
     );
-    let output = Command::new("python3")
+    let status = Command::new("python3")
         .arg("-c")
         .arg("import serde_types; import bincode; import lcs; import test_types")
         .env("PYTHONPATH", python_path)
-        .output()
+        .status()
         .unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 #[test]
@@ -91,14 +90,13 @@ __all__ = ["lcs", "serde", "bincode", "test_types"]
         std::env::var("PYTHONPATH").unwrap_or_default(),
         dir.path().to_string_lossy(),
     );
-    let output = Command::new("python3")
+    let status = Command::new("python3")
         .arg("-c")
         .arg("from my_package import serde_types; from my_package import bincode; from my_package import lcs; from my_package import test_types")
         .env("PYTHONPATH", python_path)
-        .output()
+        .status()
         .unwrap();
-    assert_eq!(String::new(), String::from_utf8_lossy(&output.stderr));
-    assert!(output.status.success());
+    assert!(status.success());
 }
 
 #[test]

--- a/serde-generate/tests/generation.rs
+++ b/serde-generate/tests/generation.rs
@@ -65,15 +65,15 @@ fn test_that_python_code_parses_with_codegen_options() {
     let content = std::fs::read_to_string(&source_path).unwrap();
     assert!(content.contains(
         r#"
-""" Some
-comments
-"""
+    """Some
+    comments
+    """
 "#
     ));
     assert!(content.contains(
         r#"
-""" Some other comments
-"""
+    """Some other comments
+    """
 "#
     ));
 


### PR DESCRIPTION
## Summary

* Fix formatting of comments
* omit INDEX and VARIANTS when serialization is skipped
* (possibly breaking) set `# pyre-strict` in generated code

## Test Plan

include unit tests + test in Libra