### PR TITLE
[serde generate] c++ runtime: share code between bincode and LCS

### DIFF
--- a/serde-generate/runtime/cpp/binary.hpp
+++ b/serde-generate/runtime/cpp/binary.hpp
@@ -1,0 +1,290 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+
+#include "serde.hpp"
+
+namespace serde {
+
+template <class S>
+class BinarySerializer {
+  protected:
+    std::vector<uint8_t> bytes_;
+
+  public:
+    BinarySerializer() {}
+
+    void serialize_str(const std::string &value);
+
+    void serialize_bool(bool value);
+    void serialize_unit();
+    void serialize_char(char32_t value);
+    void serialize_f32(float value);
+    void serialize_f64(double value);
+
+    void serialize_u8(uint8_t value);
+    void serialize_u16(uint16_t value);
+    void serialize_u32(uint32_t value);
+    void serialize_u64(uint64_t value);
+    void serialize_u128(const uint128_t &value);
+
+    void serialize_i8(int8_t value);
+    void serialize_i16(int16_t value);
+    void serialize_i32(int32_t value);
+    void serialize_i64(int64_t value);
+    void serialize_i128(const int128_t &value);
+    void serialize_option_tag(bool value);
+
+    size_t get_buffer_offset();
+
+    std::vector<uint8_t> bytes() && { return std::move(bytes_); }
+};
+
+template <class D>
+class BinaryDeserializer {
+    size_t pos_;
+
+  protected:
+    std::vector<uint8_t> bytes_;
+    uint8_t read_byte();
+
+  public:
+    BinaryDeserializer(std::vector<uint8_t> bytes) {
+        bytes_ = std::move(bytes);
+        pos_ = 0;
+    }
+
+    std::string deserialize_str();
+
+    bool deserialize_bool();
+    void deserialize_unit();
+    char32_t deserialize_char();
+    float deserialize_f32();
+    double deserialize_f64();
+
+    uint8_t deserialize_u8();
+    uint16_t deserialize_u16();
+    uint32_t deserialize_u32();
+    uint64_t deserialize_u64();
+    uint128_t deserialize_u128();
+
+    int8_t deserialize_i8();
+    int16_t deserialize_i16();
+    int32_t deserialize_i32();
+    int64_t deserialize_i64();
+    int128_t deserialize_i128();
+
+    bool deserialize_option_tag();
+
+    size_t get_buffer_offset();
+};
+
+template <class S>
+void BinarySerializer<S>::serialize_str(const std::string &value) {
+    static_cast<S*>(this)->serialize_len(value.size());
+    for (auto c : value) {
+        bytes_.push_back(c);
+    }
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_unit() {}
+
+template <class S>
+void BinarySerializer<S>::serialize_f32(float) { throw "not implemented"; }
+
+template <class S>
+void BinarySerializer<S>::serialize_f64(double) { throw "not implemented"; }
+
+template <class S>
+void BinarySerializer<S>::serialize_char(char32_t) { throw "not implemented"; }
+
+template <class S>
+void BinarySerializer<S>::serialize_bool(bool value) {
+    bytes_.push_back((uint8_t)value);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_u8(uint8_t value) {
+    bytes_.push_back(value);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_u16(uint16_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_u32(uint32_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+    bytes_.push_back((uint8_t)(value >> 16));
+    bytes_.push_back((uint8_t)(value >> 24));
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_u64(uint64_t value) {
+    bytes_.push_back((uint8_t)value);
+    bytes_.push_back((uint8_t)(value >> 8));
+    bytes_.push_back((uint8_t)(value >> 16));
+    bytes_.push_back((uint8_t)(value >> 24));
+    bytes_.push_back((uint8_t)(value >> 32));
+    bytes_.push_back((uint8_t)(value >> 40));
+    bytes_.push_back((uint8_t)(value >> 48));
+    bytes_.push_back((uint8_t)(value >> 56));
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_u128(const uint128_t &value) {
+    serialize_u64(value.low);
+    serialize_u64(value.high);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_i8(int8_t value) {
+    serialize_u8((uint8_t)value);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_i16(int16_t value) {
+    serialize_u16((uint16_t)value);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_i32(int32_t value) {
+    serialize_u32((uint32_t)value);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_i64(int64_t value) {
+    serialize_u64((uint64_t)value);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_i128(const int128_t &value) {
+    serialize_u64(value.low);
+    serialize_i64(value.high);
+}
+
+template <class S>
+void BinarySerializer<S>::serialize_option_tag(bool value) {
+    serialize_bool(value);
+}
+
+template <class S>
+size_t BinarySerializer<S>::get_buffer_offset() { return bytes_.size(); }
+
+template <class D>
+uint8_t BinaryDeserializer<D>::read_byte() { return bytes_.at(pos_++); }
+
+template <class D>
+std::string BinaryDeserializer<D>::deserialize_str() {
+    auto len = static_cast<D*>(this)->deserialize_len();
+    std::string result;
+    result.reserve(len);
+    for (size_t i = 0; i < len; i++) {
+        result.push_back(read_byte());
+    }
+    return result;
+}
+
+template <class D>
+void BinaryDeserializer<D>::deserialize_unit() {}
+
+template <class D>
+float BinaryDeserializer<D>::deserialize_f32() { throw "not implemented"; }
+
+template <class D>
+double BinaryDeserializer<D>::deserialize_f64() { throw "not implemented"; }
+
+template <class D>
+char32_t BinaryDeserializer<D>::deserialize_char() { throw "not implemented"; }
+
+template <class D>
+bool BinaryDeserializer<D>::deserialize_bool() { return (bool)read_byte(); }
+
+template <class D>
+uint8_t BinaryDeserializer<D>::deserialize_u8() { return read_byte(); }
+
+template <class D>
+uint16_t BinaryDeserializer<D>::deserialize_u16() {
+    uint16_t val = 0;
+    val |= (uint16_t)read_byte();
+    val |= (uint16_t)read_byte() << 8;
+    return val;
+}
+
+template <class D>
+uint32_t BinaryDeserializer<D>::deserialize_u32() {
+    uint32_t val = 0;
+    val |= (uint32_t)read_byte();
+    val |= (uint32_t)read_byte() << 8;
+    val |= (uint32_t)read_byte() << 16;
+    val |= (uint32_t)read_byte() << 24;
+    return val;
+}
+
+template <class D>
+uint64_t BinaryDeserializer<D>::deserialize_u64() {
+    uint64_t val = 0;
+    val |= (uint64_t)read_byte();
+    val |= (uint64_t)read_byte() << 8;
+    val |= (uint64_t)read_byte() << 16;
+    val |= (uint64_t)read_byte() << 24;
+    val |= (uint64_t)read_byte() << 32;
+    val |= (uint64_t)read_byte() << 40;
+    val |= (uint64_t)read_byte() << 48;
+    val |= (uint64_t)read_byte() << 56;
+    return val;
+}
+
+template <class D>
+uint128_t BinaryDeserializer<D>::deserialize_u128() {
+    uint128_t result;
+    result.low = deserialize_u64();
+    result.high = deserialize_u64();
+    return result;
+}
+
+template <class D>
+int8_t BinaryDeserializer<D>::deserialize_i8() {
+    return (int8_t)deserialize_u8();
+}
+
+template <class D>
+int16_t BinaryDeserializer<D>::deserialize_i16() {
+    return (int16_t)deserialize_u16();
+}
+
+template <class D>
+int32_t BinaryDeserializer<D>::deserialize_i32() {
+    return (int32_t)deserialize_u32();
+}
+
+template <class D>
+int64_t BinaryDeserializer<D>::deserialize_i64() {
+    return (int64_t)deserialize_u64();
+}
+
+template <class D>
+int128_t BinaryDeserializer<D>::deserialize_i128() {
+    int128_t result;
+    result.low = deserialize_u64();
+    result.high = deserialize_i64();
+    return result;
+}
+
+template <class D>
+bool BinaryDeserializer<D>::deserialize_option_tag() {
+    return deserialize_bool();
+}
+
+template <class D>
+size_t BinaryDeserializer<D>::get_buffer_offset() { return pos_; }
+
+} // end of namespace serde

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -4,270 +4,48 @@
 #pragma once
 
 #include "serde.hpp"
+#include "binary.hpp"
 
 namespace serde {
 
-class BincodeSerializer {
-    std::vector<uint8_t> bytes_;
+class BincodeSerializer : public BinarySerializer<BincodeSerializer> {
+    using Parent = BinarySerializer<BincodeSerializer>;
 
   public:
-    BincodeSerializer() {}
-
-    void serialize_str(const std::string &value);
-
-    void serialize_bool(bool value);
-    void serialize_unit();
-    void serialize_char(char32_t value);
-    void serialize_f32(float value);
-    void serialize_f64(double value);
-
-    void serialize_u8(uint8_t value);
-    void serialize_u16(uint16_t value);
-    void serialize_u32(uint32_t value);
-    void serialize_u64(uint64_t value);
-    void serialize_u128(const uint128_t &value);
-
-    void serialize_i8(int8_t value);
-    void serialize_i16(int16_t value);
-    void serialize_i32(int32_t value);
-    void serialize_i64(int64_t value);
-    void serialize_i128(const int128_t &value);
+    BincodeSerializer() : Parent() {}
 
     void serialize_len(size_t value);
-    void serialize_variant_index(size_t value);
-    void serialize_option_tag(bool value);
+    void serialize_variant_index(uint32_t value);
 
     static constexpr bool enforce_strict_map_ordering = false;
-
-    std::vector<uint8_t> bytes() && { return std::move(bytes_); }
 };
 
-class BincodeDeserializer {
-    std::vector<uint8_t> bytes_;
-    size_t pos_;
-
-    uint8_t read_byte();
+class BincodeDeserializer : public BinaryDeserializer<BincodeDeserializer> {
+    using Parent = BinaryDeserializer<BincodeDeserializer>;
 
   public:
-    BincodeDeserializer(std::vector<uint8_t> bytes) {
-        bytes_ = std::move(bytes);
-        pos_ = 0;
-    }
-
-    std::string deserialize_str();
-
-    bool deserialize_bool();
-    void deserialize_unit();
-    char32_t deserialize_char();
-    float deserialize_f32();
-    double deserialize_f64();
-
-    uint8_t deserialize_u8();
-    uint16_t deserialize_u16();
-    uint32_t deserialize_u32();
-    uint64_t deserialize_u64();
-    uint128_t deserialize_u128();
-
-    int8_t deserialize_i8();
-    int16_t deserialize_i16();
-    int32_t deserialize_i32();
-    int64_t deserialize_i64();
-    int128_t deserialize_i128();
+    BincodeDeserializer(std::vector<uint8_t> bytes) : Parent(std::move(bytes)) {}
 
     size_t deserialize_len();
-    size_t deserialize_variant_index();
-    bool deserialize_option_tag();
+    uint32_t deserialize_variant_index();
 
     static constexpr bool enforce_strict_map_ordering = false;
 };
 
-inline void BincodeSerializer::serialize_str(const std::string &value) {
-    serialize_len(value.size());
-    for (auto c : value) {
-        bytes_.push_back(c);
-    }
-}
-
-inline void BincodeSerializer::serialize_unit() {}
-
-inline void BincodeSerializer::serialize_f32(float) { throw "not implemented"; }
-
-inline void BincodeSerializer::serialize_f64(double) {
-    throw "not implemented";
-}
-
-inline void BincodeSerializer::serialize_char(char32_t) {
-    throw "not implemented";
-}
-
-inline void BincodeSerializer::serialize_bool(bool value) {
-    bytes_.push_back((uint8_t)value);
-}
-
-inline void BincodeSerializer::serialize_u8(uint8_t value) {
-    bytes_.push_back(value);
-}
-
-inline void BincodeSerializer::serialize_u16(uint16_t value) {
-    bytes_.push_back((uint8_t)value);
-    bytes_.push_back((uint8_t)(value >> 8));
-}
-
-inline void BincodeSerializer::serialize_u32(uint32_t value) {
-    bytes_.push_back((uint8_t)value);
-    bytes_.push_back((uint8_t)(value >> 8));
-    bytes_.push_back((uint8_t)(value >> 16));
-    bytes_.push_back((uint8_t)(value >> 24));
-}
-
-inline void BincodeSerializer::serialize_u64(uint64_t value) {
-    bytes_.push_back((uint8_t)value);
-    bytes_.push_back((uint8_t)(value >> 8));
-    bytes_.push_back((uint8_t)(value >> 16));
-    bytes_.push_back((uint8_t)(value >> 24));
-    bytes_.push_back((uint8_t)(value >> 32));
-    bytes_.push_back((uint8_t)(value >> 40));
-    bytes_.push_back((uint8_t)(value >> 48));
-    bytes_.push_back((uint8_t)(value >> 56));
-}
-
-inline void BincodeSerializer::serialize_u128(const uint128_t &value) {
-    serialize_u64(value.low);
-    serialize_u64(value.high);
-}
-
-inline void BincodeSerializer::serialize_i8(int8_t value) {
-    serialize_u8((uint8_t)value);
-}
-
-inline void BincodeSerializer::serialize_i16(int16_t value) {
-    serialize_u16((uint16_t)value);
-}
-
-inline void BincodeSerializer::serialize_i32(int32_t value) {
-    serialize_u32((uint32_t)value);
-}
-
-inline void BincodeSerializer::serialize_i64(int64_t value) {
-    serialize_u64((uint64_t)value);
-}
-
-inline void BincodeSerializer::serialize_i128(const int128_t &value) {
-    serialize_u64(value.low);
-    serialize_i64(value.high);
-}
-
 inline void BincodeSerializer::serialize_len(size_t value) {
-    serialize_u64((uint64_t)value);
+    Parent::serialize_u64((uint64_t)value);
 }
 
-inline void BincodeSerializer::serialize_variant_index(size_t value) {
-    serialize_u32((uint32_t)value);
-}
-
-inline void BincodeSerializer::serialize_option_tag(bool value) {
-    serialize_bool(value);
-}
-
-inline std::string BincodeDeserializer::deserialize_str() {
-    auto len = deserialize_len();
-    std::string result;
-    result.reserve(len);
-    for (size_t i = 0; i < len; i++) {
-        result.push_back(read_byte());
-    }
-    return result;
-}
-
-inline uint8_t BincodeDeserializer::read_byte() { return bytes_.at(pos_++); }
-
-inline void BincodeDeserializer::deserialize_unit() {}
-
-inline float BincodeDeserializer::deserialize_f32() { throw "not implemented"; }
-
-inline double BincodeDeserializer::deserialize_f64() {
-    throw "not implemented";
-}
-
-inline char32_t BincodeDeserializer::deserialize_char() {
-    throw "not implemented";
-}
-
-inline bool BincodeDeserializer::deserialize_bool() {
-    return (bool)read_byte();
-}
-
-inline uint8_t BincodeDeserializer::deserialize_u8() { return read_byte(); }
-
-inline uint16_t BincodeDeserializer::deserialize_u16() {
-    uint16_t val = 0;
-    val |= (uint16_t)read_byte();
-    val |= (uint16_t)read_byte() << 8;
-    return val;
-}
-
-inline uint32_t BincodeDeserializer::deserialize_u32() {
-    uint32_t val = 0;
-    val |= (uint32_t)read_byte();
-    val |= (uint32_t)read_byte() << 8;
-    val |= (uint32_t)read_byte() << 16;
-    val |= (uint32_t)read_byte() << 24;
-    return val;
-}
-
-inline uint64_t BincodeDeserializer::deserialize_u64() {
-    uint64_t val = 0;
-    val |= (uint64_t)read_byte();
-    val |= (uint64_t)read_byte() << 8;
-    val |= (uint64_t)read_byte() << 16;
-    val |= (uint64_t)read_byte() << 24;
-    val |= (uint64_t)read_byte() << 32;
-    val |= (uint64_t)read_byte() << 40;
-    val |= (uint64_t)read_byte() << 48;
-    val |= (uint64_t)read_byte() << 56;
-    return val;
-}
-
-inline uint128_t BincodeDeserializer::deserialize_u128() {
-    uint128_t result;
-    result.low = deserialize_u64();
-    result.high = deserialize_u64();
-    return result;
-}
-
-inline int8_t BincodeDeserializer::deserialize_i8() {
-    return (int8_t)deserialize_u8();
-}
-
-inline int16_t BincodeDeserializer::deserialize_i16() {
-    return (int16_t)deserialize_u16();
-}
-
-inline int32_t BincodeDeserializer::deserialize_i32() {
-    return (int32_t)deserialize_u32();
-}
-
-inline int64_t BincodeDeserializer::deserialize_i64() {
-    return (int64_t)deserialize_u64();
-}
-
-inline int128_t BincodeDeserializer::deserialize_i128() {
-    int128_t result;
-    result.low = deserialize_u64();
-    result.high = deserialize_i64();
-    return result;
+inline void BincodeSerializer::serialize_variant_index(uint32_t value) {
+    Parent::serialize_u32((uint32_t)value);
 }
 
 inline size_t BincodeDeserializer::deserialize_len() {
-    return (size_t)deserialize_u64();
+    return (size_t)Parent::deserialize_u64();
 }
 
-inline size_t BincodeDeserializer::deserialize_variant_index() {
-    return (size_t)deserialize_u32();
-}
-
-inline bool BincodeDeserializer::deserialize_option_tag() {
-    return deserialize_bool();
+inline uint32_t BincodeDeserializer::deserialize_variant_index() {
+    return Parent::deserialize_u32();
 }
 
 } // end of namespace serde

--- a/serde-generate/runtime/cpp/lcs.hpp
+++ b/serde-generate/runtime/cpp/lcs.hpp
@@ -7,90 +7,40 @@
 #include <cassert>
 
 #include "serde.hpp"
+#include "binary.hpp"
 
 namespace serde {
 
 // Maximum length supported for LCS sequences and maps.
 constexpr size_t LCS_MAX_LENGTH = 1ull << 31;
 
-class LcsSerializer {
-    std::vector<uint8_t> bytes_;
+class LcsSerializer : public BinarySerializer<LcsSerializer> {
+    using Parent = BinarySerializer<LcsSerializer>;
 
     void serialize_u32_as_uleb128(uint32_t);
 
   public:
-    LcsSerializer() {}
-
-    void serialize_str(const std::string &value);
-
-    void serialize_bool(bool value);
-    void serialize_unit();
-    void serialize_char(char32_t value);
-    void serialize_f32(float value);
-    void serialize_f64(double value);
-
-    void serialize_u8(uint8_t value);
-    void serialize_u16(uint16_t value);
-    void serialize_u32(uint32_t value);
-    void serialize_u64(uint64_t value);
-    void serialize_u128(const uint128_t &value);
-
-    void serialize_i8(int8_t value);
-    void serialize_i16(int16_t value);
-    void serialize_i32(int32_t value);
-    void serialize_i64(int64_t value);
-    void serialize_i128(const int128_t &value);
+    LcsSerializer() : Parent() {}
 
     void serialize_len(size_t value);
-    void serialize_variant_index(size_t value);
-    void serialize_option_tag(bool value);
+    void serialize_variant_index(uint32_t value);
 
     static constexpr bool enforce_strict_map_ordering = true;
-    size_t get_buffer_offset();
     void sort_last_entries(std::vector<size_t> offsets);
-
-    std::vector<uint8_t> bytes() && { return std::move(bytes_); }
 };
 
-class LcsDeserializer {
-    std::vector<uint8_t> bytes_;
-    size_t pos_;
+class LcsDeserializer : public BinaryDeserializer<LcsDeserializer> {
+    using Parent = BinaryDeserializer<LcsDeserializer>;
 
-    uint8_t read_byte();
     uint32_t deserialize_uleb128_as_u32();
 
   public:
-    LcsDeserializer(std::vector<uint8_t> bytes) {
-        bytes_ = std::move(bytes);
-        pos_ = 0;
-    }
-
-    std::string deserialize_str();
-
-    bool deserialize_bool();
-    void deserialize_unit();
-    char32_t deserialize_char();
-    float deserialize_f32();
-    double deserialize_f64();
-
-    uint8_t deserialize_u8();
-    uint16_t deserialize_u16();
-    uint32_t deserialize_u32();
-    uint64_t deserialize_u64();
-    uint128_t deserialize_u128();
-
-    int8_t deserialize_i8();
-    int16_t deserialize_i16();
-    int32_t deserialize_i32();
-    int64_t deserialize_i64();
-    int128_t deserialize_i128();
+    LcsDeserializer(std::vector<uint8_t> bytes) : Parent(std::move(bytes)) {}
 
     size_t deserialize_len();
-    size_t deserialize_variant_index();
-    bool deserialize_option_tag();
+    uint32_t deserialize_variant_index();
 
     static constexpr bool enforce_strict_map_ordering = true;
-    size_t get_buffer_offset();
     void check_that_key_slices_are_increasing(std::tuple<size_t, size_t> key1,
                                               std::tuple<size_t, size_t> key2);
 };
@@ -103,78 +53,6 @@ inline void LcsSerializer::serialize_u32_as_uleb128(uint32_t value) {
     bytes_.push_back((uint8_t)value);
 }
 
-inline void LcsSerializer::serialize_str(const std::string &value) {
-    serialize_len(value.size());
-    for (auto c : value) {
-        bytes_.push_back(c);
-    }
-}
-
-inline void LcsSerializer::serialize_unit() {}
-
-inline void LcsSerializer::serialize_f32(float) { throw "not implemented"; }
-
-inline void LcsSerializer::serialize_f64(double) { throw "not implemented"; }
-
-inline void LcsSerializer::serialize_char(char32_t) { throw "not implemented"; }
-
-inline void LcsSerializer::serialize_bool(bool value) {
-    bytes_.push_back((uint8_t)value);
-}
-
-inline void LcsSerializer::serialize_u8(uint8_t value) {
-    bytes_.push_back(value);
-}
-
-inline void LcsSerializer::serialize_u16(uint16_t value) {
-    bytes_.push_back((uint8_t)value);
-    bytes_.push_back((uint8_t)(value >> 8));
-}
-
-inline void LcsSerializer::serialize_u32(uint32_t value) {
-    bytes_.push_back((uint8_t)value);
-    bytes_.push_back((uint8_t)(value >> 8));
-    bytes_.push_back((uint8_t)(value >> 16));
-    bytes_.push_back((uint8_t)(value >> 24));
-}
-
-inline void LcsSerializer::serialize_u64(uint64_t value) {
-    bytes_.push_back((uint8_t)value);
-    bytes_.push_back((uint8_t)(value >> 8));
-    bytes_.push_back((uint8_t)(value >> 16));
-    bytes_.push_back((uint8_t)(value >> 24));
-    bytes_.push_back((uint8_t)(value >> 32));
-    bytes_.push_back((uint8_t)(value >> 40));
-    bytes_.push_back((uint8_t)(value >> 48));
-    bytes_.push_back((uint8_t)(value >> 56));
-}
-
-inline void LcsSerializer::serialize_u128(const uint128_t &value) {
-    serialize_u64(value.low);
-    serialize_u64(value.high);
-}
-
-inline void LcsSerializer::serialize_i8(int8_t value) {
-    serialize_u8((uint8_t)value);
-}
-
-inline void LcsSerializer::serialize_i16(int16_t value) {
-    serialize_u16((uint16_t)value);
-}
-
-inline void LcsSerializer::serialize_i32(int32_t value) {
-    serialize_u32((uint32_t)value);
-}
-
-inline void LcsSerializer::serialize_i64(int64_t value) {
-    serialize_u64((uint64_t)value);
-}
-
-inline void LcsSerializer::serialize_i128(const int128_t &value) {
-    serialize_u64(value.low);
-    serialize_i64(value.high);
-}
-
 inline void LcsSerializer::serialize_len(size_t value) {
     if (value > LCS_MAX_LENGTH) {
         throw "Length is too large";
@@ -182,15 +60,9 @@ inline void LcsSerializer::serialize_len(size_t value) {
     serialize_u32_as_uleb128((uint32_t)value);
 }
 
-inline void LcsSerializer::serialize_variant_index(size_t value) {
-    serialize_u32_as_uleb128((uint32_t)value);
+inline void LcsSerializer::serialize_variant_index(uint32_t value) {
+    serialize_u32_as_uleb128(value);
 }
-
-inline void LcsSerializer::serialize_option_tag(bool value) {
-    serialize_bool(value);
-}
-
-inline size_t LcsSerializer::get_buffer_offset() { return bytes_.size(); }
 
 inline void LcsSerializer::sort_last_entries(std::vector<size_t> offsets) {
     if (offsets.size() <= 1) {
@@ -217,8 +89,6 @@ inline void LcsSerializer::sort_last_entries(std::vector<size_t> offsets) {
     assert(offsets.back() == bytes_.size());
 }
 
-inline uint8_t LcsDeserializer::read_byte() { return bytes_.at(pos_++); }
-
 inline uint32_t LcsDeserializer::deserialize_uleb128_as_u32() {
     uint64_t value = 0;
     for (int shift = 0; shift < 32; shift += 7) {
@@ -238,87 +108,6 @@ inline uint32_t LcsDeserializer::deserialize_uleb128_as_u32() {
     throw "Overflow while parsing uleb128-encoded uint32 value";
 }
 
-inline std::string LcsDeserializer::deserialize_str() {
-    auto len = deserialize_len();
-    std::string result;
-    result.reserve(len);
-    for (size_t i = 0; i < len; i++) {
-        result.push_back(read_byte());
-    }
-    return result;
-}
-
-inline void LcsDeserializer::deserialize_unit() {}
-
-inline float LcsDeserializer::deserialize_f32() { throw "not implemented"; }
-
-inline double LcsDeserializer::deserialize_f64() { throw "not implemented"; }
-
-inline char32_t LcsDeserializer::deserialize_char() { throw "not implemented"; }
-
-inline bool LcsDeserializer::deserialize_bool() { return (bool)read_byte(); }
-
-inline uint8_t LcsDeserializer::deserialize_u8() { return read_byte(); }
-
-inline uint16_t LcsDeserializer::deserialize_u16() {
-    uint16_t val = 0;
-    val |= (uint16_t)read_byte();
-    val |= (uint16_t)read_byte() << 8;
-    return val;
-}
-
-inline uint32_t LcsDeserializer::deserialize_u32() {
-    uint32_t val = 0;
-    val |= (uint32_t)read_byte();
-    val |= (uint32_t)read_byte() << 8;
-    val |= (uint32_t)read_byte() << 16;
-    val |= (uint32_t)read_byte() << 24;
-    return val;
-}
-
-inline uint64_t LcsDeserializer::deserialize_u64() {
-    uint64_t val = 0;
-    val |= (uint64_t)read_byte();
-    val |= (uint64_t)read_byte() << 8;
-    val |= (uint64_t)read_byte() << 16;
-    val |= (uint64_t)read_byte() << 24;
-    val |= (uint64_t)read_byte() << 32;
-    val |= (uint64_t)read_byte() << 40;
-    val |= (uint64_t)read_byte() << 48;
-    val |= (uint64_t)read_byte() << 56;
-    return val;
-}
-
-inline uint128_t LcsDeserializer::deserialize_u128() {
-    uint128_t result;
-    result.low = deserialize_u64();
-    result.high = deserialize_u64();
-    return result;
-}
-
-inline int8_t LcsDeserializer::deserialize_i8() {
-    return (int8_t)deserialize_u8();
-}
-
-inline int16_t LcsDeserializer::deserialize_i16() {
-    return (int16_t)deserialize_u16();
-}
-
-inline int32_t LcsDeserializer::deserialize_i32() {
-    return (int32_t)deserialize_u32();
-}
-
-inline int64_t LcsDeserializer::deserialize_i64() {
-    return (int64_t)deserialize_u64();
-}
-
-inline int128_t LcsDeserializer::deserialize_i128() {
-    int128_t result;
-    result.low = deserialize_u64();
-    result.high = deserialize_i64();
-    return result;
-}
-
 inline size_t LcsDeserializer::deserialize_len() {
     auto value = deserialize_uleb128_as_u32();
     if (value > LCS_MAX_LENGTH) {
@@ -327,15 +116,9 @@ inline size_t LcsDeserializer::deserialize_len() {
     return (size_t)value;
 }
 
-inline size_t LcsDeserializer::deserialize_variant_index() {
-    return (size_t)deserialize_uleb128_as_u32();
+inline uint32_t LcsDeserializer::deserialize_variant_index() {
+    return deserialize_uleb128_as_u32();
 }
-
-inline bool LcsDeserializer::deserialize_option_tag() {
-    return deserialize_bool();
-}
-
-inline size_t LcsDeserializer::get_buffer_offset() { return pos_; }
 
 inline void LcsDeserializer::check_that_key_slices_are_increasing(
     std::tuple<size_t, size_t> key1, std::tuple<size_t, size_t> key2) {


### PR DESCRIPTION
## Summary

Share code between Bincode and LCS. This is similar to what we do in Java but in the spirit of C++, we use the [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) instead of virtual method calls.

## Test Plan

existing tests