### PR TITLE
add golang runtime tests into build; fix lcs serializer

### DIFF
--- a/serde-generate/runtime/golang/lcs/serializer.go
+++ b/serde-generate/runtime/golang/lcs/serializer.go
@@ -145,7 +145,7 @@ func (s *Serializer) GetBufferOffset() uint64 {
 }
 
 // SortMapEntries is unimplemented.
-func (s *Serializer) SortMapEntries(offsets []int) {
+func (s *Serializer) SortMapEntries(offsets []uint64) {
 	panic("unimplemented")
 }
 

--- a/serde-generate/tests/runtimes.rs
+++ b/serde-generate/tests/runtimes.rs
@@ -700,3 +700,22 @@ fn test_java_lcs_runtime_autotest() {
         .unwrap();
     assert!(status.success());
 }
+
+#[test]
+fn test_golang_runtime_tests() {
+    let mut runtime_mod_path = std::env::current_exe().unwrap();
+    runtime_mod_path = runtime_mod_path.to_owned();
+    runtime_mod_path.pop();
+    runtime_mod_path.pop();
+    runtime_mod_path.pop();
+    runtime_mod_path.pop();
+    runtime_mod_path.push("serde-generate/runtime/golang");
+
+    let status = Command::new("go")
+        .current_dir(runtime_mod_path.as_os_str().to_str().unwrap())
+        .arg("test")
+        .arg("./...")
+        .status()
+        .unwrap();
+    assert!(status.success());
+}


### PR DESCRIPTION
## Summary

Broken change added in my previous diff at last min, because runtime golang tests was not run with build.

This diff adds the test and fix the lcs serializer.

## Test Plan

cargo test -p serde-generate --test golang_generation
