### PR TITLE
[Serde generate] various fixes in codegen

### DIFF
--- a/serde-generate/src/common.rs
+++ b/serde-generate/src/common.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde_reflection::Format;
+
+pub(crate) fn mangle_type(format: &Format) -> String {
+    use Format::*;
+    match format {
+        TypeName(x) => x.to_string(),
+        Unit => "unit".into(),
+        Bool => "bool".into(),
+        I8 => "i8".into(),
+        I16 => "i16".into(),
+        I32 => "i32".into(),
+        I64 => "i64".into(),
+        I128 => "i128".into(),
+        U8 => "u8".into(),
+        U16 => "u16".into(),
+        U32 => "u32".into(),
+        U64 => "u64".into(),
+        U128 => "u128".into(),
+        F32 => "f32".into(),
+        F64 => "f64".into(),
+        Char => "char".into(),
+        Str => "str".into(),
+        Bytes => "bytes".into(),
+
+        Option(format) => format!("option_{}", mangle_type(format)),
+        Seq(format) => format!("vector_{}", mangle_type(format)),
+        Map { key, value } => format!("map_{}_to_{}", mangle_type(key), mangle_type(value)),
+        Tuple(formats) => format!(
+            "tuple{}_{}",
+            formats.len(),
+            formats
+                .iter()
+                .map(mangle_type)
+                .collect::<Vec<_>>()
+                .join("_")
+        ),
+        TupleArray { content, size } => format!("array{}_{}_array", size, mangle_type(content)),
+        Variable(_) => panic!("unexpected value"),
+    }
+}

--- a/serde-generate/src/config.rs
+++ b/serde-generate/src/config.rs
@@ -65,7 +65,11 @@ impl CodeGeneratorConfig {
     }
 
     /// Comments attached to particular entity.
-    pub fn with_comments(mut self, comments: DocComments) -> Self {
+    pub fn with_comments(mut self, mut comments: DocComments) -> Self {
+        // Make sure comments end with a (single) newline.
+        for comment in comments.values_mut() {
+            *comment = format!("{}\n", comment.trim());
+        }
         self.comments = comments;
         self
     }

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -479,6 +479,8 @@ impl crate::SourceInstaller for Installer {
     fn install_serde_runtime(&self) -> std::result::Result<(), Self::Error> {
         let mut file = self.create_header_file("serde")?;
         write!(file, "{}", include_str!("../runtime/cpp/serde.hpp"))?;
+        let mut file = self.create_header_file("binary")?;
+        write!(file, "{}", include_str!("../runtime/cpp/binary.hpp"))?;
         Ok(())
     }
 

--- a/serde-generate/src/cpp.rs
+++ b/serde-generate/src/cpp.rs
@@ -145,7 +145,7 @@ where
         path.push(name.to_string());
         if let Some(doc) = self.generator.config.comments.get(&path) {
             let text = textwrap::indent(doc, "/// ").replace("\n\n", "\n///\n");
-            write!(self.out, "\n{}", text)?;
+            write!(self.out, "{}", text)?;
         }
         Ok(())
     }
@@ -223,6 +223,7 @@ where
 
     fn output_fields(&mut self, fields: &[Named<Format>]) -> Result<()> {
         for field in fields {
+            self.output_comment(&field.name)?;
             writeln!(
                 self.out,
                 "{} {};",
@@ -234,6 +235,7 @@ where
     }
 
     fn output_variant(&mut self, name: &str, variant: &VariantFormat) -> Result<()> {
+        writeln!(self.out)?;
         self.output_comment(name)?;
         use VariantFormat::*;
         let operator = format!("friend bool operator==(const {}&, const {}&);", name, name);
@@ -254,6 +256,7 @@ where
                 operator
             ),
             Struct(fields) => {
+                writeln!(self.out)?;
                 self.output_comment(name)?;
                 writeln!(self.out, "struct {} {{", name)?;
                 self.enter_class(name);

--- a/serde-generate/src/generate.rs
+++ b/serde-generate/src/generate.rs
@@ -60,7 +60,7 @@ struct Options {
     #[structopt(long)]
     module_name: Option<String>,
 
-    /// Optional package name where to find the `serde_types` module (useful in Python).
+    /// Optional package name (Python) or module path (Go) where to find Serde runtime dependencies.
     #[structopt(long)]
     serde_package_name: Option<String>,
 }
@@ -119,7 +119,9 @@ fn main() {
                     Language::Rust => Box::new(rust::Installer::new(install_dir)),
                     Language::Cpp => Box::new(cpp::Installer::new(install_dir)),
                     Language::Java => Box::new(java::Installer::new(install_dir)),
-                    Language::Go => Box::new(golang::Installer::new(install_dir)),
+                    Language::Go => {
+                        Box::new(golang::Installer::new(install_dir, serde_package_name_opt))
+                    }
                 };
 
             if let Some((registry, name)) = named_registry_opt {

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
+    common,
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig,
 };
@@ -184,7 +185,7 @@ where
             format
                 .visit(&mut |f| {
                     if Self::needs_helper(f) {
-                        subtypes.insert(Self::mangle_type(f), f.clone());
+                        subtypes.insert(common::mangle_type(f), f.clone());
                     }
                     Ok(())
                 })
@@ -195,52 +196,6 @@ where
             self.output_deserialization_helper(mangled_name, subtype)?;
         }
         Ok(())
-    }
-
-    // TODO: share
-    fn mangle_type(format: &Format) -> String {
-        use Format::*;
-        match format {
-            TypeName(x) => x.to_string(),
-            Unit => "unit".into(),
-            Bool => "bool".into(),
-            I8 => "i8".into(),
-            I16 => "i16".into(),
-            I32 => "i32".into(),
-            I64 => "i64".into(),
-            I128 => "i128".into(),
-            U8 => "u8".into(),
-            U16 => "u16".into(),
-            U32 => "u32".into(),
-            U64 => "u64".into(),
-            U128 => "u128".into(),
-            F32 => "f32".into(),
-            F64 => "f64".into(),
-            Char => "char".into(),
-            Str => "str".into(),
-            Bytes => "bytes".into(),
-
-            Option(format) => format!("option_{}", Self::mangle_type(format)),
-            Seq(format) => format!("vector_{}", Self::mangle_type(format)),
-            Map { key, value } => format!(
-                "map_{}_to_{}",
-                Self::mangle_type(key),
-                Self::mangle_type(value)
-            ),
-            Tuple(formats) => format!(
-                "tuple{}_{}",
-                formats.len(),
-                formats
-                    .iter()
-                    .map(Self::mangle_type)
-                    .collect::<Vec<_>>()
-                    .join("_")
-            ),
-            TupleArray { content, size } => {
-                format!("array{}_{}_array", size, Self::mangle_type(content))
-            }
-            Variable(_) => panic!("unexpected value"),
-        }
     }
 
     fn needs_helper(format: &Format) -> bool {
@@ -274,7 +229,7 @@ where
             Bytes => format!("serializer.SerializeBytes({})", value),
             _ => format!(
                 "serialize_{}({}, serializer)",
-                Self::mangle_type(format),
+                common::mangle_type(format),
                 value
             ),
         };
@@ -305,7 +260,7 @@ where
             Char => "deserializer.DeserializeChar()".to_string(),
             Str => "deserializer.DeserializeStr()".to_string(),
             Bytes => "deserializer.DeserializeBytes()".to_string(),
-            _ => format!("deserialize_{}(deserializer)", Self::mangle_type(format)),
+            _ => format!("deserialize_{}(deserializer)", common::mangle_type(format)),
         };
         format!(
             "{{ val, err := {}; if err != nil {{ return {}, err }} else {{ {} = val }} }}",

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -506,7 +506,13 @@ return obj, nil
                     value: f.clone(),
                 })
                 .collect(),
-            Struct(fields) => fields.clone(),
+            Struct(fields) => fields
+                .iter()
+                .map(|f| Named {
+                    name: f.name.to_camel_case(),
+                    value: f.value.clone(),
+                })
+                .collect(),
             Variable(_) => panic!("incorrect value"),
         };
         self.output_struct_or_variant_container(Some(base), Some(index), name, &fields)
@@ -677,7 +683,19 @@ switch index {{"#,
                 })
                 .collect(),
             Enum(variants) => {
-                self.output_enum_container(name, variants)?;
+                let variants = variants
+                    .iter()
+                    .map(|(i, f)| {
+                        (
+                            *i,
+                            Named {
+                                name: f.name.to_camel_case(),
+                                value: f.value.clone(),
+                            },
+                        )
+                    })
+                    .collect();
+                self.output_enum_container(name, &variants)?;
                 return Ok(());
             }
         };

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -550,7 +550,7 @@ return obj, nil
         if self.generator.config.serialization {
             writeln!(
                 self.out,
-                "\nfunc (obj *{}) Serialize(serializer serde.Serializer) error {{",
+                "\nfunc (obj {}) Serialize(serializer serde.Serializer) error {{",
                 full_name
             )?;
             self.out.indent();
@@ -561,7 +561,7 @@ return obj, nil
                 writeln!(
                     self.out,
                     "{}",
-                    self.quote_serialize_value(&format!("(*obj).{}", &field.name), &field.value)
+                    self.quote_serialize_value(&format!("obj.{}", &field.name), &field.value)
                 )?;
             }
             writeln!(self.out, "return nil")?;

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -109,7 +109,7 @@ where
         path.push(name.to_string());
         if let Some(doc) = self.generator.config.comments.get(&path) {
             let text = textwrap::indent(doc, "// ").replace("\n\n", "\n//\n");
-            writeln!(self.out, "{}", text)?;
+            write!(self.out, "{}", text)?;
         }
         Ok(())
     }

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
+    common,
     indent::{IndentConfig, IndentedWriter},
     CodeGeneratorConfig,
 };
@@ -253,7 +254,7 @@ where
             format
                 .visit(&mut |f| {
                     if Self::needs_helper(f) {
-                        subtypes.insert(Self::mangle_type(f), f.clone());
+                        subtypes.insert(common::mangle_type(f), f.clone());
                     }
                     Ok(())
                 })
@@ -268,51 +269,6 @@ where
         }
         self.leave_class(reserved_names);
         writeln!(self.out, "}}\n")
-    }
-
-    fn mangle_type(format: &Format) -> String {
-        use Format::*;
-        match format {
-            TypeName(x) => x.to_string(),
-            Unit => "unit".into(),
-            Bool => "bool".into(),
-            I8 => "i8".into(),
-            I16 => "i16".into(),
-            I32 => "i32".into(),
-            I64 => "i64".into(),
-            I128 => "i128".into(),
-            U8 => "u8".into(),
-            U16 => "u16".into(),
-            U32 => "u32".into(),
-            U64 => "u64".into(),
-            U128 => "u128".into(),
-            F32 => "f32".into(),
-            F64 => "f64".into(),
-            Char => "char".into(),
-            Str => "str".into(),
-            Bytes => "bytes".into(),
-
-            Option(format) => format!("option_{}", Self::mangle_type(format)),
-            Seq(format) => format!("vector_{}", Self::mangle_type(format)),
-            Map { key, value } => format!(
-                "map_{}_to_{}",
-                Self::mangle_type(key),
-                Self::mangle_type(value)
-            ),
-            Tuple(formats) => format!(
-                "tuple{}_{}",
-                formats.len(),
-                formats
-                    .iter()
-                    .map(Self::mangle_type)
-                    .collect::<Vec<_>>()
-                    .join("_")
-            ),
-            TupleArray { content, size } => {
-                format!("array{}_{}_array", size, Self::mangle_type(content))
-            }
-            Variable(_) => panic!("unexpected value"),
-        }
     }
 
     fn needs_helper(format: &Format) -> bool {
@@ -347,7 +303,7 @@ where
             _ => format!(
                 "{}.serialize_{}({}, serializer);",
                 self.quote_qualified_name("TraitHelpers"),
-                Self::mangle_type(format),
+                common::mangle_type(format),
                 value
             ),
         }
@@ -380,7 +336,7 @@ where
             _ => format!(
                 "{}.deserialize_{}(deserializer)",
                 self.quote_qualified_name("TraitHelpers"),
-                Self::mangle_type(format),
+                common::mangle_type(format),
             ),
         }
     }

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -133,6 +133,8 @@ pub mod rust;
 /// Utility functions to help testing code generators.
 pub mod test_utils;
 
+/// Common logic for codegen.
+mod common;
 /// Common configuration objects and traits used in public APIs.
 mod config;
 

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -179,7 +179,7 @@ import typing
         let mut path = self.current_namespace.clone();
         path.push(name.to_string());
         if let Some(doc) = self.generator.config.comments.get(&path) {
-            writeln!(self.out, "\"\"\"{}\n\"\"\"", doc)?;
+            writeln!(self.out, "\"\"\"{}\"\"\"", doc)?;
         }
         Ok(())
     }

--- a/serde-generate/tests/golang_generation.rs
+++ b/serde-generate/tests/golang_generation.rs
@@ -30,14 +30,11 @@ fn test_that_golang_code_compiles_with_config(
         .unwrap();
     assert!(status.success());
 
-    let mut runtime_mod_path = std::env::current_exe().unwrap();
-    runtime_mod_path = runtime_mod_path.to_owned();
-    runtime_mod_path.pop();
-    runtime_mod_path.pop();
-    runtime_mod_path.pop();
-    runtime_mod_path.pop();
-    runtime_mod_path.push("serde-generate/runtime/golang");
-
+    let runtime_mod_path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("../../../serde-generate/runtime/golang");
     let status = Command::new("go")
         .current_dir(dir.path())
         .arg("mod")
@@ -45,7 +42,7 @@ fn test_that_golang_code_compiles_with_config(
         .arg("-replace")
         .arg(format!(
             "github.com/facebookincubator/serde-reflection/serde-generate/runtime/golang={}",
-            runtime_mod_path.as_os_str().to_str().unwrap()
+            runtime_mod_path.to_str().unwrap()
         ))
         .status()
         .unwrap();

--- a/serde-generate/tests/runtimes.rs
+++ b/serde-generate/tests/runtimes.rs
@@ -703,16 +703,14 @@ fn test_java_lcs_runtime_autotest() {
 
 #[test]
 fn test_golang_runtime_tests() {
-    let mut runtime_mod_path = std::env::current_exe().unwrap();
-    runtime_mod_path = runtime_mod_path.to_owned();
-    runtime_mod_path.pop();
-    runtime_mod_path.pop();
-    runtime_mod_path.pop();
-    runtime_mod_path.pop();
-    runtime_mod_path.push("serde-generate/runtime/golang");
+    let runtime_mod_path = std::env::current_exe()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("../../../serde-generate/runtime/golang");
 
     let status = Command::new("go")
-        .current_dir(runtime_mod_path.as_os_str().to_str().unwrap())
+        .current_dir(runtime_mod_path.to_str().unwrap())
         .arg("test")
         .arg("./...")
         .status()


### PR DESCRIPTION
## Summary

Many small fixes and improvements. Notably in the recent Go codegen:
* fix external definitions (adding missing imports)
* fix field names that were still in small caps (hence private)
* make `Installer` usable: now create a subdirectory for the package and a file `lib.go`
* remove the latest call-by-pointer (Serialize) => turns out this simplifies greatly enums (making `Enum__Variant` an `Enum` instead of `&Enum__Variant`)

## Test Plan

unit tests + used in my next libra PR