### PR TITLE
[serde generate] fix fatal warning in Go

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "bincode",
  "heck",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.11.2"
+version = "0.11.3"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"


### PR DESCRIPTION
## Summary

Sadly, there is no way to disable the warning "unused import" in Go and it's fatal.
Combined with the fact that imports are mandatory (no alternatives with a fully qualified name), this is a bummer but anyways I made it work.

## Test Plan

included unit tests