### PR TITLE
[Serde generate] Go: pass structs by pointer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "bincode",
  "heck",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.11.3"
+version = "0.12.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -576,14 +576,14 @@ return obj, nil
 
         // Link to base interface.
         if let Some(base) = variant_base {
-            writeln!(self.out, "\nfunc ({}) is{}() {{}}", full_name, base)?;
+            writeln!(self.out, "\nfunc (*{}) is{}() {{}}", full_name, base)?;
         }
 
         // Serialize
         if self.generator.config.serialization {
             writeln!(
                 self.out,
-                "\nfunc (obj {}) Serialize(serializer serde.Serializer) error {{",
+                "\nfunc (obj *{}) Serialize(serializer serde.Serializer) error {{",
                 full_name
             )?;
             self.out.indent();


### PR DESCRIPTION
## Summary

Per popular demand, we are reverting 89c5f4eb5b59 to avoid copying data while passing container values as arguments. The goal is to use pointers consistently where one would have used `const&` in C++ or `&` Rust.

Also, changing `isBla` to take a pointer receiver so that type-ckecking in user code is not affected when switching `config.serialization` on and off.

## Test Plan

unit test