### PR TITLE
[serde generate] Go: LCS maps + fixes

### DIFF
--- a/serde-generate/runtime/golang/lcs/lcs_test.go
+++ b/serde-generate/runtime/golang/lcs/lcs_test.go
@@ -720,3 +720,25 @@ func TestGetBufferOffset(t *testing.T) {
 	d.DeserializeU64()
 	assert.Equal(t, uint64(8), d.GetBufferOffset())
 }
+
+func TestCheckThatKeySlicesAreIncreasing(t *testing.T) {
+	d := lcs.NewDeserializer([]byte{0, 1, 2, 0, 2})
+	// Offsets are taken from the input bytes.
+	d.DeserializeU32()
+	require.NoError(t, d.CheckThatKeySlicesAreIncreasing(serde.Slice{0, 3}, serde.Slice{3, 5}))
+	require.Error(t, d.CheckThatKeySlicesAreIncreasing(serde.Slice{0, 3}, serde.Slice{0, 3}))
+	require.Error(t, d.CheckThatKeySlicesAreIncreasing(serde.Slice{1, 3}, serde.Slice{3, 5}))
+}
+
+func TestSortMapEntries(t *testing.T) {
+	s := lcs.NewSerializer()
+	s.SerializeU8(255)
+	s.SerializeU32(1)
+	s.SerializeU32(1)
+	s.SerializeU32(2)
+	assert.Equal(t, s.GetBytes(), []byte{255 /**/, 1 /**/, 0, 0 /**/, 0, 1, 0 /**/, 0 /**/, 0 /**/, 2, 0, 0, 0})
+
+	offsets := []uint64{1, 2, 4, 7, 8, 9}
+	s.SortMapEntries(offsets)
+	assert.Equal(t, s.GetBytes(), []byte{255 /**/, 0 /**/, 0 /**/, 0, 0 /**/, 0, 1, 0 /**/, 1 /**/, 2, 0, 0, 0})
+}

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -4,7 +4,7 @@
 use crate::{
     common,
     indent::{IndentConfig, IndentedWriter},
-    CodeGeneratorConfig,
+    CodeGeneratorConfig, Encoding,
 };
 use heck::CamelCase;
 use serde_reflection::{ContainerFormat, Format, FormatHolder, Named, Registry, VariantFormat};
@@ -343,7 +343,7 @@ where
                 write!(
                     self.out,
                     r#"
-if (value != nil) {{
+if value != nil {{
 	if err := serializer.SerializeOptionTag(true); err != nil {{ return err }}
 	{}
 }} else {{
@@ -431,11 +431,13 @@ for _, item := range(value) {{
                     r#"
 tag, err := deserializer.DeserializeOptionTag()
 if err != nil {{ return nil, err }}
-var value *{}
-if (tag) {{
+if tag {{
+	value := new({})
 	{}
+        return value, nil
+}} else {{
+	return nil, nil
 }}
-return value, nil
 "#,
                     self.quote_type(format),
                     self.quote_deserialize(format, "*value", "nil"),
@@ -473,7 +475,7 @@ for i := 0; i < int(length); i++ {{
 	var key {0}
 	{2}
 	slice.End = deserializer.GetBufferOffset()
-	if (i > 0) {{
+	if i > 0 {{
 		err := deserializer.CheckThatKeySlicesAreIncreasing(previous_slice, slice)
 		if err != nil {{ return nil, err }}
 	}}
@@ -614,18 +616,7 @@ return obj, nil
             writeln!(self.out, "}}")?;
 
             for encoding in &self.generator.config.encodings {
-                writeln!(
-                    self.out,
-                    r#"
-func (obj *{0}) {2}Serialize() ([]byte, error) {{
-	serializer := {1}.NewSerializer();
-	if err := obj.Serialize(serializer); err != nil {{ return nil, err }}
-	return serializer.GetBytes(), nil
-}}"#,
-                    full_name,
-                    encoding.name(),
-                    encoding.name().to_camel_case()
-                )?;
+                self.output_struct_serialize_for_encoding(&full_name, *encoding)?;
             }
         }
         // Deserialize (struct) or Load (variant)
@@ -655,9 +646,40 @@ func (obj *{0}) {2}Serialize() ([]byte, error) {{
 
             if variant_base.is_none() {
                 for encoding in &self.generator.config.encodings {
-                    writeln!(
-                        self.out,
-                        r#"
+                    self.output_struct_deserialize_for_encoding(&full_name, *encoding)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn output_struct_serialize_for_encoding(
+        &mut self,
+        name: &str,
+        encoding: Encoding,
+    ) -> Result<()> {
+        writeln!(
+            self.out,
+            r#"
+func (obj *{0}) {2}Serialize() ([]byte, error) {{
+	serializer := {1}.NewSerializer();
+	if err := obj.Serialize(serializer); err != nil {{ return nil, err }}
+	return serializer.GetBytes(), nil
+}}"#,
+            name,
+            encoding.name(),
+            encoding.name().to_camel_case()
+        )
+    }
+
+    fn output_struct_deserialize_for_encoding(
+        &mut self,
+        name: &str,
+        encoding: Encoding,
+    ) -> Result<()> {
+        writeln!(
+            self.out,
+            r#"
 func {2}Deserialize{0}(input []byte) ({0}, error) {{
 	deserializer := {1}.NewDeserializer(input);
 	obj, err := Deserialize{0}(deserializer)
@@ -666,14 +688,10 @@ func {2}Deserialize{0}(input []byte) ({0}, error) {{
 	}}
 	return obj, err
 }}"#,
-                        full_name,
-                        encoding.name(),
-                        encoding.name().to_camel_case()
-                    )?;
-                }
-            }
-        }
-        Ok(())
+            name,
+            encoding.name(),
+            encoding.name().to_camel_case()
+        )
     }
 
     fn output_enum_container(
@@ -689,6 +707,13 @@ func {2}Deserialize{0}(input []byte) ({0}, error) {{
         writeln!(self.out, "is{}()", name)?;
         if self.generator.config.serialization {
             writeln!(self.out, "Serialize(serializer serde.Serializer) error")?;
+            for encoding in &self.generator.config.encodings {
+                writeln!(
+                    self.out,
+                    "{}Serialize() ([]byte, error)",
+                    encoding.name().to_camel_case()
+                )?;
+            }
         }
         self.out.unindent();
         writeln!(self.out, "}}")?;
@@ -730,6 +755,10 @@ switch index {{"#,
             writeln!(self.out, "}}")?;
             self.out.unindent();
             writeln!(self.out, "}}")?;
+
+            for encoding in &self.generator.config.encodings {
+                self.output_struct_deserialize_for_encoding(name, *encoding)?;
+            }
         }
 
         for (index, variant) in variants {


### PR DESCRIPTION
## Summary

* Support LCS maps
* This makes it possible to use the same testing suite as other languages (covering all LCS types). 
* Fix deserialization of option types
* Add missing LcsSerialize on enums

## Test Plan

unit tests