### PR TITLE
[serde-generate] Go: bincode runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "bincode",
  "heck",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.12.2"
+version = "0.13.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/facebookincubator/serde-reflection"

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -17,8 +17,6 @@ The following target languages are currently supported:
 * Java 8
 * Python 3
 * Rust 2018
-
-In progress:
 * Go >= 1.13
 
 ### Supported Encodings

--- a/serde-generate/runtime/golang/bincode/deserializer.go
+++ b/serde-generate/runtime/golang/bincode/deserializer.go
@@ -1,0 +1,38 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package bincode
+
+import (
+	"github.com/facebookincubator/serde-reflection/serde-generate/runtime/golang/serde"
+)
+
+// `deserializer` extends `serde.BinaryDeserializer` to implement `serde.Deserializer`.
+type deserializer struct {
+	serde.BinaryDeserializer
+}
+
+func NewDeserializer(input []byte) serde.Deserializer {
+	return &deserializer{*serde.NewBinaryDeserializer(input)}
+}
+
+func (d *deserializer) DeserializeBytes() ([]byte, error) {
+	return d.BinaryDeserializer.DeserializeBytes(d.DeserializeLen)
+}
+
+func (d *deserializer) DeserializeStr() (string, error) {
+	return d.BinaryDeserializer.DeserializeStr(d.DeserializeLen)
+}
+
+func (d *deserializer) DeserializeLen() (uint64, error) {
+	return d.DeserializeU64()
+}
+
+func (d *deserializer) DeserializeVariantIndex() (uint32, error) {
+	return d.DeserializeU32()
+}
+
+func (d *deserializer) CheckThatKeySlicesAreIncreasing(key1, key2 serde.Slice) error {
+	// No need to check key ordering in Bincode.
+	return nil
+}

--- a/serde-generate/runtime/golang/bincode/serializer.go
+++ b/serde-generate/runtime/golang/bincode/serializer.go
@@ -1,0 +1,37 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package bincode
+
+import (
+	"github.com/facebookincubator/serde-reflection/serde-generate/runtime/golang/serde"
+)
+
+// `serializer` extends `serde.BinarySerializer` to implement `serde.Serializer`.
+type serializer struct {
+	serde.BinarySerializer
+}
+
+func NewSerializer() serde.Serializer {
+	return new(serializer)
+}
+
+func (s *serializer) SerializeStr(value string) error {
+	return s.BinarySerializer.SerializeStr(value, s.SerializeLen)
+}
+
+func (s *serializer) SerializeBytes(value []byte) error {
+	return s.BinarySerializer.SerializeBytes(value, s.SerializeLen)
+}
+
+func (s *serializer) SerializeLen(value uint64) error {
+	return s.SerializeU64(value)
+}
+
+func (s *serializer) SerializeVariantIndex(value uint32) error {
+	return s.SerializeU32(value)
+}
+
+func (s *serializer) SortMapEntries(offsets []uint64) {
+	// No need to sort map entries in Bincode.
+}

--- a/serde-generate/runtime/golang/lcs/deserializer.go
+++ b/serde-generate/runtime/golang/lcs/deserializer.go
@@ -6,7 +6,6 @@ package lcs
 import (
 	"bytes"
 	"errors"
-	"fmt"
 
 	"github.com/facebookincubator/serde-reflection/serde-generate/runtime/golang/serde"
 )
@@ -16,29 +15,24 @@ const MaxSequenceLength = (1 << 31) - 1
 
 const maxUint32 = uint64(^uint32(0))
 
-// Deserializer implements `serde.Deserializer` interface for deserializing LCS serialized bytes.
-type Deserializer struct {
-	buf *bytes.Buffer
-	// Underlying bytes in `buf`.
-	input []byte
+// `deserializer` extends `serde.BinaryDeserializer` to implement `serde.Deserializer`.
+type deserializer struct {
+	serde.BinaryDeserializer
 }
 
-// NewDeserializer creates a new `serde.Deserializer`.
 func NewDeserializer(input []byte) serde.Deserializer {
-	return &Deserializer{buf: bytes.NewBuffer(input), input: input}
+	return &deserializer{*serde.NewBinaryDeserializer(input)}
 }
 
-func (d *Deserializer) DeserializeBytes() ([]byte, error) {
-	len, err := d.DeserializeLen()
-	if err != nil {
-		return nil, err
-	}
-	ret := make([]byte, len)
-	_, err = d.buf.Read(ret)
-	return ret, err
+func (d *deserializer) DeserializeBytes() ([]byte, error) {
+	return d.BinaryDeserializer.DeserializeBytes(d.DeserializeLen)
 }
 
-func (d *Deserializer) DeserializeLen() (uint64, error) {
+func (d *deserializer) DeserializeStr() (string, error) {
+	return d.BinaryDeserializer.DeserializeStr(d.DeserializeLen)
+}
+
+func (d *deserializer) DeserializeLen() (uint64, error) {
 	ret, err := d.deserializeUleb128AsU32()
 	if ret > MaxSequenceLength {
 		return 0, errors.New("length is too large")
@@ -46,153 +40,21 @@ func (d *Deserializer) DeserializeLen() (uint64, error) {
 	return uint64(ret), err
 }
 
-func (d *Deserializer) DeserializeStr() (string, error) {
-	bytes, err := d.DeserializeBytes()
-	return string(bytes), err
-}
-
-func (d *Deserializer) DeserializeBool() (bool, error) {
-	ret, err := d.buf.ReadByte()
-	if err != nil {
-		return false, err
-	}
-	switch ret {
-	case 0:
-		return false, nil
-	case 1:
-		return true, nil
-	default:
-		return false, fmt.Errorf("invalid bool byte: expected 0 / 1, but got %d", ret)
-	}
-}
-
-func (d *Deserializer) DeserializeUnit() (struct{}, error) {
-	return struct{}{}, nil
-}
-
-// DeserializeChar is unimplemented.
-func (d *Deserializer) DeserializeChar() (rune, error) {
-	return 0, errors.New("unimplemented")
-}
-
-// DeserializeF32 is unimplemented.
-func (d *Deserializer) DeserializeF32() (float32, error) {
-	return 0, errors.New("unimplemented")
-}
-
-// DeserializeF64 is unimplemented.
-func (d *Deserializer) DeserializeF64() (float64, error) {
-	return 0, errors.New("unimplemented")
-}
-
-func (d *Deserializer) DeserializeU8() (uint8, error) {
-	ret, err := d.buf.ReadByte()
-	return uint8(ret), err
-}
-
-func (d *Deserializer) DeserializeU16() (uint16, error) {
-	var ret uint16
-	for i := 0; i < 8*2; i += 8 {
-		b, err := d.buf.ReadByte()
-		if err != nil {
-			return 0, err
-		}
-		ret = ret | uint16(b)<<i
-	}
-	return ret, nil
-}
-
-func (d *Deserializer) DeserializeU32() (uint32, error) {
-	var ret uint32
-	for i := 0; i < 8*4; i += 8 {
-		b, err := d.buf.ReadByte()
-		if err != nil {
-			return 0, err
-		}
-		ret = ret | uint32(b)<<i
-	}
-	return ret, nil
-}
-
-func (d *Deserializer) DeserializeU64() (uint64, error) {
-	var ret uint64
-	for i := 0; i < 8*8; i += 8 {
-		b, err := d.buf.ReadByte()
-		if err != nil {
-			return 0, err
-		}
-		ret = ret | uint64(b)<<i
-	}
-	return ret, nil
-}
-
-func (d *Deserializer) DeserializeU128() (serde.Uint128, error) {
-	low, err := d.DeserializeU64()
-	if err != nil {
-		return serde.Uint128{}, err
-	}
-	high, err := d.DeserializeU64()
-	if err != nil {
-		return serde.Uint128{}, err
-	}
-	return serde.Uint128{High: high, Low: low}, nil
-}
-
-func (d *Deserializer) DeserializeI8() (int8, error) {
-	ret, err := d.DeserializeU8()
-	return int8(ret), err
-}
-
-func (d *Deserializer) DeserializeI16() (int16, error) {
-	ret, err := d.DeserializeU16()
-	return int16(ret), err
-}
-
-func (d *Deserializer) DeserializeI32() (int32, error) {
-	ret, err := d.DeserializeU32()
-	return int32(ret), err
-}
-
-func (d *Deserializer) DeserializeI64() (int64, error) {
-	ret, err := d.DeserializeU64()
-	return int64(ret), err
-}
-
-func (d *Deserializer) DeserializeI128() (serde.Int128, error) {
-	low, err := d.DeserializeU64()
-	if err != nil {
-		return serde.Int128{}, err
-	}
-	high, err := d.DeserializeI64()
-	if err != nil {
-		return serde.Int128{}, err
-	}
-	return serde.Int128{High: high, Low: low}, nil
-}
-
-func (d *Deserializer) DeserializeVariantIndex() (uint32, error) {
+func (d *deserializer) DeserializeVariantIndex() (uint32, error) {
 	return d.deserializeUleb128AsU32()
 }
 
-func (d *Deserializer) DeserializeOptionTag() (bool, error) {
-	return d.DeserializeBool()
-}
-
-func (d *Deserializer) GetBufferOffset() uint64 {
-	return uint64(len(d.input)) - uint64(d.buf.Len())
-}
-
-func (d *Deserializer) CheckThatKeySlicesAreIncreasing(key1, key2 serde.Slice) error {
-	if bytes.Compare(d.input[key1.Start:key1.End], d.input[key2.Start:key2.End]) >= 0 {
+func (d *deserializer) CheckThatKeySlicesAreIncreasing(key1, key2 serde.Slice) error {
+	if bytes.Compare(d.Input[key1.Start:key1.End], d.Input[key2.Start:key2.End]) >= 0 {
 		return errors.New("Error while decoding map: keys are not serialized in the expected order")
 	}
 	return nil
 }
 
-func (d *Deserializer) deserializeUleb128AsU32() (uint32, error) {
+func (d *deserializer) deserializeUleb128AsU32() (uint32, error) {
 	var value uint64
 	for shift := 0; shift < 32; shift += 7 {
-		byte, err := d.buf.ReadByte()
+		byte, err := d.Buffer.ReadByte()
 		if err != nil {
 			return 0, err
 		}

--- a/serde-generate/runtime/golang/lcs/lcs_test.go
+++ b/serde-generate/runtime/golang/lcs/lcs_test.go
@@ -30,7 +30,7 @@ func TestSerializeDeserializeBytes(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeBytes(tc.target)
@@ -67,7 +67,7 @@ func TestSerializeDeserializeStr(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.target, func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeStr(tc.target)
@@ -104,7 +104,7 @@ func TestSerializeDeserializeBool(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeBool(tc.target)
@@ -144,7 +144,7 @@ func TestSerializeDeserializeUnit(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeUnit(tc.target)
@@ -176,7 +176,7 @@ func TestSerializeDeserializeU8(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeU8(tc.target)
@@ -218,7 +218,7 @@ func TestSerializeDeserializeU16(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeU16(tc.target)
@@ -263,7 +263,7 @@ func TestSerializeDeserializeU32(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeU32(tc.target)
@@ -312,7 +312,7 @@ func TestSerializeDeserializeU64(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeU64(tc.target)
@@ -374,7 +374,7 @@ func TestSerializeDeserializeU128(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeU128(tc.target)
@@ -411,7 +411,7 @@ func TestSerializeDeserializeI8(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeI8(tc.target)
@@ -452,7 +452,7 @@ func TestSerializeDeserializeI16(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeI16(tc.target)
@@ -493,7 +493,7 @@ func TestSerializeDeserializeI32(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeI32(tc.target)
@@ -537,7 +537,7 @@ func TestSerializeDeserializeI64(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeI64(tc.target)
@@ -589,7 +589,7 @@ func TestSerializeDeserializeI128(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeI128(tc.target)
@@ -622,7 +622,7 @@ func TestSerializeDeserializeVariantIndex(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeVariantIndex(tc.target)
@@ -643,13 +643,13 @@ func TestSerializeDeserializeVariantIndex(t *testing.T) {
 
 func TestSerializeDeserializeLenLimit(t *testing.T) {
 	t.Run("SerializeLen: length is too large", func(t *testing.T) {
-		s := new(lcs.Serializer)
+		s := lcs.NewSerializer()
 		err := s.SerializeLen(^uint64(0))
 		assert.Error(t, err)
 		assert.Equal(t, "length is too large", err.Error())
 	})
 	t.Run("DeserializeLen: length is too large", func(t *testing.T) {
-		s := new(lcs.Serializer)
+		s := lcs.NewSerializer()
 		err := s.SerializeVariantIndex(^uint32(0))
 		assert.NoError(t, err)
 
@@ -691,7 +691,7 @@ func TestSerializeDeserializeOptionTag(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("%#v", tc.target), func(t *testing.T) {
-			s := new(lcs.Serializer)
+			s := lcs.NewSerializer()
 			d := lcs.NewDeserializer(tc.expected)
 
 			err := s.SerializeOptionTag(tc.target)
@@ -711,7 +711,7 @@ func TestSerializeDeserializeOptionTag(t *testing.T) {
 }
 
 func TestGetBufferOffset(t *testing.T) {
-	s := new(lcs.Serializer)
+	s := lcs.NewSerializer()
 	s.SerializeU64(0)
 	assert.Equal(t, uint64(8), s.GetBufferOffset())
 

--- a/serde-generate/runtime/golang/lcs/serializer.go
+++ b/serde-generate/runtime/golang/lcs/serializer.go
@@ -11,21 +11,24 @@ import (
 	"github.com/facebookincubator/serde-reflection/serde-generate/runtime/golang/serde"
 )
 
-// Serializer implements `serde.Serializer` interface for serializing LCS bytes.
-type Serializer struct {
-	buf bytes.Buffer
+// `serializer` extends `serde.BinarySerializer` to implement `serde.Serializer`.
+type serializer struct {
+	serde.BinarySerializer
 }
 
-// NewSerializer creates a new `serde.Serializer`.
 func NewSerializer() serde.Serializer {
-	return new(Serializer)
+	return new(serializer)
 }
 
-func (s *Serializer) GetBytes() []byte {
-	return s.buf.Bytes()
+func (s *serializer) SerializeStr(value string) error {
+	return s.BinarySerializer.SerializeStr(value, s.SerializeLen)
 }
 
-func (s *Serializer) SerializeLen(value uint64) error {
+func (s *serializer) SerializeBytes(value []byte) error {
+	return s.BinarySerializer.SerializeBytes(value, s.SerializeLen)
+}
+
+func (s *serializer) SerializeLen(value uint64) error {
 	if value > MaxSequenceLength {
 		return errors.New("length is too large")
 	}
@@ -33,127 +36,20 @@ func (s *Serializer) SerializeLen(value uint64) error {
 	return nil
 }
 
-func (s *Serializer) SerializeBytes(value []byte) error {
-	s.SerializeLen(uint64(len(value)))
-	s.buf.Write(value)
-	return nil
-}
-
-func (s *Serializer) SerializeStr(value string) error {
-	return s.SerializeBytes([]byte(value))
-}
-
-func (s *Serializer) SerializeBool(value bool) error {
-	if value {
-		return s.buf.WriteByte(1)
-	}
-	return s.buf.WriteByte(0)
-}
-
-func (s *Serializer) SerializeUnit(value struct{}) error {
-	return nil
-}
-
-// SerializeChar is unimplemented.
-func (s *Serializer) SerializeChar(value rune) error {
-	return errors.New("unimplemented")
-}
-
-// SerializeF32 is unimplemented
-func (s *Serializer) SerializeF32(value float32) error {
-	return errors.New("unimplemented")
-}
-
-// SerializeF64 is unimplemented
-func (s *Serializer) SerializeF64(value float64) error {
-	return errors.New("unimplemented")
-}
-
-func (s *Serializer) SerializeU8(value uint8) error {
-	s.buf.WriteByte(byte(value))
-	return nil
-}
-
-func (s *Serializer) SerializeU16(value uint16) error {
-	s.buf.WriteByte(byte(value))
-	s.buf.WriteByte(byte(value >> 8))
-	return nil
-}
-
-func (s *Serializer) SerializeU32(value uint32) error {
-	s.buf.WriteByte(byte(value))
-	s.buf.WriteByte(byte(value >> 8))
-	s.buf.WriteByte(byte(value >> 16))
-	s.buf.WriteByte(byte(value >> 24))
-	return nil
-}
-
-func (s *Serializer) SerializeU64(value uint64) error {
-	s.buf.WriteByte(byte(value))
-	s.buf.WriteByte(byte(value >> 8))
-	s.buf.WriteByte(byte(value >> 16))
-	s.buf.WriteByte(byte(value >> 24))
-	s.buf.WriteByte(byte(value >> 32))
-	s.buf.WriteByte(byte(value >> 40))
-	s.buf.WriteByte(byte(value >> 48))
-	s.buf.WriteByte(byte(value >> 56))
-	return nil
-}
-
-func (s *Serializer) SerializeU128(value serde.Uint128) error {
-	s.SerializeU64(value.Low)
-	s.SerializeU64(value.High)
-	return nil
-}
-
-func (s *Serializer) SerializeI8(value int8) error {
-	s.SerializeU8(uint8(value))
-	return nil
-}
-
-func (s *Serializer) SerializeI16(value int16) error {
-	s.SerializeU16(uint16(value))
-	return nil
-}
-
-func (s *Serializer) SerializeI32(value int32) error {
-	s.SerializeU32(uint32(value))
-	return nil
-}
-
-func (s *Serializer) SerializeI64(value int64) error {
-	s.SerializeU64(uint64(value))
-	return nil
-}
-
-func (s *Serializer) SerializeI128(value serde.Int128) error {
-	s.SerializeU64(value.Low)
-	s.SerializeI64(value.High)
-	return nil
-}
-
-func (s *Serializer) SerializeVariantIndex(value uint32) error {
+func (s *serializer) SerializeVariantIndex(value uint32) error {
 	s.serializeU32AsUleb128(value)
 	return nil
 }
 
-func (s *Serializer) SerializeOptionTag(value bool) error {
-	return s.SerializeBool(value)
-}
-
-func (s *Serializer) GetBufferOffset() uint64 {
-	return uint64(s.buf.Len())
-}
-
-func (s *Serializer) SortMapEntries(offsets []uint64) {
+func (s *serializer) SortMapEntries(offsets []uint64) {
 	if len(offsets) <= 1 {
 		return
 	}
-	data := s.GetBytes()
+	data := s.Buffer.Bytes()
 	slices := make([]serde.Slice, len(offsets))
 	for i, v := range offsets {
 		var w uint64
-		if i + 1 < len(offsets) {
+		if i+1 < len(offsets) {
 			w = offsets[i+1]
 		} else {
 			w = uint64(len(data))
@@ -170,13 +66,13 @@ func (s *Serializer) SortMapEntries(offsets []uint64) {
 	copy(data[offsets[0]:], current)
 }
 
-func (s *Serializer) serializeU32AsUleb128(value uint32) {
+func (s *serializer) serializeU32AsUleb128(value uint32) {
 	for value >= 0x80 {
 		b := byte((value & 0x7f) | 0x80)
-		_ = s.buf.WriteByte(b)
+		_ = s.Buffer.WriteByte(b)
 		value = value >> 7
 	}
-	_ = s.buf.WriteByte(byte(value))
+	_ = s.Buffer.WriteByte(byte(value))
 }
 
 type map_entries struct {

--- a/serde-generate/runtime/golang/serde/binary_deserializer.go
+++ b/serde-generate/runtime/golang/serde/binary_deserializer.go
@@ -1,0 +1,168 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// `BinaryDeserializer` is a partial implementation of the `Deserializer` interface.
+// It is used as an embedded struct by the Bincode and LCS deserializers.
+type BinaryDeserializer struct {
+	Buffer *bytes.Buffer
+	Input  []byte
+}
+
+func NewBinaryDeserializer(input []byte) *BinaryDeserializer {
+	return &BinaryDeserializer{
+		Buffer: bytes.NewBuffer(input),
+		Input:  input,
+	}
+}
+
+// `deserializeLen` to be provided by the extending struct.
+func (d *BinaryDeserializer) DeserializeBytes(deserializeLen func() (uint64, error)) ([]byte, error) {
+	len, err := deserializeLen()
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]byte, len)
+	_, err = d.Buffer.Read(ret)
+	return ret, err
+}
+
+// `deserializeLen` to be provided by the extending struct.
+func (d *BinaryDeserializer) DeserializeStr(deserializeLen func() (uint64, error)) (string, error) {
+	bytes, err := d.DeserializeBytes(deserializeLen)
+	return string(bytes), err
+}
+
+func (d *BinaryDeserializer) DeserializeBool() (bool, error) {
+	ret, err := d.Buffer.ReadByte()
+	if err != nil {
+		return false, err
+	}
+	switch ret {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid bool byte: expected 0 / 1, but got %d", ret)
+	}
+}
+
+func (d *BinaryDeserializer) DeserializeUnit() (struct{}, error) {
+	return struct{}{}, nil
+}
+
+// DeserializeChar is unimplemented.
+func (d *BinaryDeserializer) DeserializeChar() (rune, error) {
+	return 0, errors.New("unimplemented")
+}
+
+// DeserializeF32 is unimplemented.
+func (d *BinaryDeserializer) DeserializeF32() (float32, error) {
+	return 0, errors.New("unimplemented")
+}
+
+// DeserializeF64 is unimplemented.
+func (d *BinaryDeserializer) DeserializeF64() (float64, error) {
+	return 0, errors.New("unimplemented")
+}
+
+func (d *BinaryDeserializer) DeserializeU8() (uint8, error) {
+	ret, err := d.Buffer.ReadByte()
+	return uint8(ret), err
+}
+
+func (d *BinaryDeserializer) DeserializeU16() (uint16, error) {
+	var ret uint16
+	for i := 0; i < 8*2; i += 8 {
+		b, err := d.Buffer.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		ret = ret | uint16(b)<<i
+	}
+	return ret, nil
+}
+
+func (d *BinaryDeserializer) DeserializeU32() (uint32, error) {
+	var ret uint32
+	for i := 0; i < 8*4; i += 8 {
+		b, err := d.Buffer.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		ret = ret | uint32(b)<<i
+	}
+	return ret, nil
+}
+
+func (d *BinaryDeserializer) DeserializeU64() (uint64, error) {
+	var ret uint64
+	for i := 0; i < 8*8; i += 8 {
+		b, err := d.Buffer.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		ret = ret | uint64(b)<<i
+	}
+	return ret, nil
+}
+
+func (d *BinaryDeserializer) DeserializeU128() (Uint128, error) {
+	low, err := d.DeserializeU64()
+	if err != nil {
+		return Uint128{}, err
+	}
+	high, err := d.DeserializeU64()
+	if err != nil {
+		return Uint128{}, err
+	}
+	return Uint128{High: high, Low: low}, nil
+}
+
+func (d *BinaryDeserializer) DeserializeI8() (int8, error) {
+	ret, err := d.DeserializeU8()
+	return int8(ret), err
+}
+
+func (d *BinaryDeserializer) DeserializeI16() (int16, error) {
+	ret, err := d.DeserializeU16()
+	return int16(ret), err
+}
+
+func (d *BinaryDeserializer) DeserializeI32() (int32, error) {
+	ret, err := d.DeserializeU32()
+	return int32(ret), err
+}
+
+func (d *BinaryDeserializer) DeserializeI64() (int64, error) {
+	ret, err := d.DeserializeU64()
+	return int64(ret), err
+}
+
+func (d *BinaryDeserializer) DeserializeI128() (Int128, error) {
+	low, err := d.DeserializeU64()
+	if err != nil {
+		return Int128{}, err
+	}
+	high, err := d.DeserializeI64()
+	if err != nil {
+		return Int128{}, err
+	}
+	return Int128{High: high, Low: low}, nil
+}
+
+func (d *BinaryDeserializer) DeserializeOptionTag() (bool, error) {
+	return d.DeserializeBool()
+}
+
+func (d *BinaryDeserializer) GetBufferOffset() uint64 {
+	return uint64(len(d.Input)) - uint64(d.Buffer.Len())
+}

--- a/serde-generate/runtime/golang/serde/binary_serializer.go
+++ b/serde-generate/runtime/golang/serde/binary_serializer.go
@@ -1,0 +1,132 @@
+// Copyright (c) Facebook, Inc. and its affiliates
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+package serde
+
+import (
+	"bytes"
+	"errors"
+)
+
+// `BinarySerializer` is a partial implementation of the `Serializer` interface.
+// It is used as an embedded struct by the Bincode and LCS serializers.
+type BinarySerializer struct {
+	Buffer bytes.Buffer
+}
+
+func NewBinarySerializer() *BinarySerializer {
+	return new(BinarySerializer)
+}
+
+// `serializeLen` to be provided by the extending struct.
+func (s *BinarySerializer) SerializeBytes(value []byte, serializeLen func(uint64) error) error {
+	serializeLen(uint64(len(value)))
+	s.Buffer.Write(value)
+	return nil
+}
+
+// `serializeLen` to be provided by the extending struct.
+func (s *BinarySerializer) SerializeStr(value string, serializeLen func(uint64) error) error {
+	return s.SerializeBytes([]byte(value), serializeLen)
+}
+
+func (s *BinarySerializer) SerializeBool(value bool) error {
+	if value {
+		return s.Buffer.WriteByte(1)
+	}
+	return s.Buffer.WriteByte(0)
+}
+
+func (s *BinarySerializer) SerializeUnit(value struct{}) error {
+	return nil
+}
+
+// SerializeChar is unimplemented.
+func (s *BinarySerializer) SerializeChar(value rune) error {
+	return errors.New("unimplemented")
+}
+
+// SerializeF32 is unimplemented
+func (s *BinarySerializer) SerializeF32(value float32) error {
+	return errors.New("unimplemented")
+}
+
+// SerializeF64 is unimplemented
+func (s *BinarySerializer) SerializeF64(value float64) error {
+	return errors.New("unimplemented")
+}
+
+func (s *BinarySerializer) SerializeU8(value uint8) error {
+	s.Buffer.WriteByte(byte(value))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeU16(value uint16) error {
+	s.Buffer.WriteByte(byte(value))
+	s.Buffer.WriteByte(byte(value >> 8))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeU32(value uint32) error {
+	s.Buffer.WriteByte(byte(value))
+	s.Buffer.WriteByte(byte(value >> 8))
+	s.Buffer.WriteByte(byte(value >> 16))
+	s.Buffer.WriteByte(byte(value >> 24))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeU64(value uint64) error {
+	s.Buffer.WriteByte(byte(value))
+	s.Buffer.WriteByte(byte(value >> 8))
+	s.Buffer.WriteByte(byte(value >> 16))
+	s.Buffer.WriteByte(byte(value >> 24))
+	s.Buffer.WriteByte(byte(value >> 32))
+	s.Buffer.WriteByte(byte(value >> 40))
+	s.Buffer.WriteByte(byte(value >> 48))
+	s.Buffer.WriteByte(byte(value >> 56))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeU128(value Uint128) error {
+	s.SerializeU64(value.Low)
+	s.SerializeU64(value.High)
+	return nil
+}
+
+func (s *BinarySerializer) SerializeI8(value int8) error {
+	s.SerializeU8(uint8(value))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeI16(value int16) error {
+	s.SerializeU16(uint16(value))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeI32(value int32) error {
+	s.SerializeU32(uint32(value))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeI64(value int64) error {
+	s.SerializeU64(uint64(value))
+	return nil
+}
+
+func (s *BinarySerializer) SerializeI128(value Int128) error {
+	s.SerializeU64(value.Low)
+	s.SerializeI64(value.High)
+	return nil
+}
+
+func (s *BinarySerializer) SerializeOptionTag(value bool) error {
+	return s.SerializeBool(value)
+}
+
+func (s *BinarySerializer) GetBufferOffset() uint64 {
+	return uint64(s.Buffer.Len())
+}
+
+func (s *BinarySerializer) GetBytes() []byte {
+	return s.Buffer.Bytes()
+}

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -12,8 +12,6 @@
 //! * Java 8
 //! * Python 3
 //! * Rust 2018
-//!
-//! In progress:
 //! * Go >= 1.13
 //!
 //! ## Supported Encodings

--- a/serde-generate/tests/golang_generation.rs
+++ b/serde-generate/tests/golang_generation.rs
@@ -108,6 +108,13 @@ fn test_that_golang_code_compiles_with_lcs() {
 }
 
 #[test]
+fn test_that_golang_code_compiles_with_bincode() {
+    let config =
+        CodeGeneratorConfig::new("main".to_string()).with_encodings(vec![Encoding::Bincode]);
+    test_that_golang_code_compiles_with_config(&config);
+}
+
+#[test]
 fn test_that_golang_code_compiles_with_comments() {
     let comments = vec![
         (


### PR DESCRIPTION
## Summary

* Provide a bincode runtime in Go.
* The code is largely shared with LCS, following other language implementations.
* This tentatively concludes the work on adding Go to serde-generate.

## Test Plan

unit test